### PR TITLE
Implementation of CP-APR using ALTO format

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ MIT License
 
 Copyright (c) 2021 Intel Corporation
 Copyright (c) 2021 University of Oregon
+All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,28 @@ DEFINES += -DALTO_RANKS_SPECIALIZED=$(subst $(space),,$(RANKS_SPECIALIZED))
 ifeq ($(THP_PRE_ALLOCATION),true)
 DEFINES += -DALTO_PRE_ALLOC
 endif
-ifeq ($(ALTERNATIVE_PEXT),true)
+ifeq ($(strip $(ALTERNATIVE_PEXT)),true)
 DEFINES += -DALT_PEXT
 endif
-ifeq ($(MEMTRACE),true)
+ifeq ($(strip $(MEMTRACE)),true)
 DEFINES += -DALTO_MEM_TRACE
 endif
-ifeq ($(DEBUG),true)
+ifeq ($(strip $(DEBUG)),true)
 DEFINES += -DALTO_DEBUG
 endif
-ifeq ($(BLAS_LIBRARY),MKL)
+ifeq ($(strip $(BLAS_LIBRARY)),MKL)
 DEFINES += -DMKL
+endif
+ifeq ($(strip $(ALTO_IDX_TYPE)),INT32)
+DEFINES += -DIDX_TYPE32
+endif
+ifeq ($(strip $(ALTO_FP_TYPE)),FP32)
+DEFINES += -DFP_TYPE32
+endif
+ifeq ($(strip $(ALTO_VAL_TYPE)),INT32)
+DEFINES += -DVAL_TYPE_INT32
+else ifeq ($(strip $(ALTO_VAL_TYPE)),INT64)
+DEFINES += -DVAL_TYPE_INT64
 endif
 
 INCLUDES += -I$(INC_DIR)
@@ -62,7 +73,7 @@ $(BUILD_DIR)/%.o:  $(SRC_DIR)/%.cpp
 	@echo "===>  COMPILE  $@"
 	$(CXX) -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
-$(BUILD_DIR)/%.s:  $(SRC_DIR)/%.c
+$(BUILD_DIR)/%.s:  $(SRC_DIR)/%.cpp
 	@echo "===>  GENERATE ASM  $@"
 	$(CXX) -S $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Currently, `MKL` or any library that conforms to the BLAS interface (tested with
 #### Length of ALTO mask
 Set `ALTO_MASK_LENGTH` either to `64` or `128` for a 64-bit or 128-bit ALTO-mask, respectively.
 
+#### Data types
+By default, ALTO uses 64-bit integers as index type and double precision as kruskal tensor and sparse tensor value types.
+You can adjust these data types the following way:
+| variable name   | description               | options          |
+|-----------------|---------------------------|------------------|
+| `ALTO_IDX_TYPE` | index type                | `INT32`, `INT64` |
+| `ALTO_FP_TYPE`  | kruskal tensor value type | `FP32` (float), `FP64` (double) |
+| `ALTO_VAL_TYPE` | sparse tensor value type  | `INT32`, `INT64`, `FP_TYPE` (same as `ALTO_FP_TYPE`) |
+
 #### Mode and Rank Specialization
 The build system is setup so that certain mode and rank combinations are optimized at compile time.  To specify which modes and ranks are optimized, set MODES_SPECIALIZED and RANKS_SPECIALIZED to a comma-separated list of the desired values. To disable either mode or rank specialization, use 0 as the value to be specialized.
 
@@ -65,6 +74,7 @@ For getting specific information about the memory access patterns in particular 
 * Jesmin Jahan Tithi (jesmin.jahan.tithi@intel.com)
 * Jeewhan Choi (jeec@uoregon.edu)
 * Yongseok Soh (ysoh@uoregon.edu)
+* S. Isaac Geronimo Anderson (igeroni3@uoregon.edu)
 
 ## Licensing
 ALTO is released under the MIT License. Please see the 'LICENSE' file for details.

--- a/config.mk
+++ b/config.mk
@@ -12,6 +12,14 @@ BLAS_LIBRARY = MKL
 # either 64 or 128
 ALTO_MASK_LENGTH = 64
 
+# Data types (default: idx_type=int64, ktensor_val_type=double, sptensor_val_type=double)
+## possible options: INT32, INT64
+ALTO_IDX_TYPE = INT64
+## possible options: FP32, FP64
+ALTO_FP_TYPE = FP64
+## possible options: INT32, INT64, FP_TYPE
+ALTO_VAL_TYPE = FP_TYPE
+
 # List of modes and ranks to specialize code for; use 0 to
 # disable specialization.
 MODES_SPECIALIZED := 3, 4, 5

--- a/include/apr.hpp
+++ b/include/apr.hpp
@@ -1342,23 +1342,22 @@ cp_apr_alto(AltoTensor<LIT>* AT, KruskalModel* M, int max_iters, int max_inner_i
     fprintf(stdout, "CP-APR post-processing time = %f (s)\n", wtime_post);
     fprintf(stdout, "CP-APR TOTAL time           = %f (s)\n",
             wtime_pre + wtime_apr + wtime_post);
-
-    fprintf(stdout, "Time per iteration          = %f (s)\n",
+    fprintf(stdout, "Time per iteration          = %f (s)\n\n",
             (wtime_pre + wtime_apr + wtime_post)/nTotalInner);
 
-    fprintf(stdout, "%f,%f,%.2f,%f,%f,%f,%f,%f,%f,%f,%d,%d,%d,%d,%d,%d,%d,%e,%e,%e,%d,%d,%s,%f\n",
-            wtime_pre, wtime_apr, 0.0, wtime_apr_phi, wtime_post,
-            modeTimes[0], nmodes > 1 ? modeTimes[1] : 0, nmodes > 2 ? modeTimes[2] : 0,
-            nmodes > 3 ? modeTimes[3] : 0, nmodes > 4 ? modeTimes[4] : 0,
+    fprintf(stdout, "outer-its  inner-its  its-mode1  its-mode2  its-mode3  its-mode4  its-mode5  ");
+    fprintf(stdout, "LL           LSF         KKT         max-o-its  max-i-its  mem-mgmt\n");
+    fprintf(stdout, "%-7d    %-7d    %-7d    %-7d    %-7d    %-7d    %-7d    %07.4e  %07.4e  %07.4e  %-7d    %-7d    %-7s\n",
             iter, nTotalInner, nInnerItersPerMode[0], nInnerItersPerMode[1],
             nInnerItersPerMode[2], nmodes > 3 ? nInnerItersPerMode[3] : 0, nmodes > 4 ? nInnerItersPerMode[4] : 0,
             obj, fit, kktViolations[iter-1], max_iters, max_inner_iters,
-            needPhiPrecomp ? "pre" : needPhiPrecomp ? "dyn" : "otf",
-            (wtime_pre + wtime_apr + wtime_post)/nTotalInner);
-    //printf("%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f\n", (wtime_pre + wtime_apr + wtime_post)/nTotalInner, modeTimes[0], modeTimes[0]/nTotalInner,
-    //                                                modeTimes[1], modeTimes[1]/nTotalInner, modeTimes[2], modeTimes[2]/nTotalInner,
-    //                                                modeTimes[3], modeTimes[3]/nTotalInner, modeTimes[4], modeTimes[4]/nTotalInner,
-    //                                                );
+            needPhiPrecomp ? "pre" : needPhiPrecomp ? "dyn" : "otf");
+    fprintf(stdout, "Total    Pre-proc  CP-APR   Phi      Post-proc  mode1    mode2    ");
+    fprintf(stdout, "mode3    mode4    mode5    time-per-it\n");
+    fprintf(stdout, "%07.4f  %07.4f   %07.4f  %07.4f  %07.4f    %07.4f  %07.4f  %07.4f  %07.4f  %07.4f  %07.4f\n",
+            wtime_pre + wtime_apr + wtime_post, wtime_pre, wtime_apr, wtime_apr_phi, wtime_post,
+            modeTimes[0], nmodes > 1 ? modeTimes[1] : 0, nmodes > 2 ? modeTimes[2] : 0, nmodes > 3 ? modeTimes[3] : 0,
+            nmodes > 4 ? modeTimes[4] : 0, (wtime_pre + wtime_apr + wtime_post)/nTotalInner);
 
     // for (int n = 0; n < nmodes; n++) {
     //     AlignedFree(Phi[n]);

--- a/include/apr.hpp
+++ b/include/apr.hpp
@@ -1285,6 +1285,9 @@ cp_apr_alto(AltoTensor<LIT>* AT, KruskalModel* M, int max_iters, int max_inner_i
     }
     AlignedFree(Phi);
     if (needPhiPrecomp) AlignedFree(AT->precomp_row);
+    AlignedFree(kktModeViolations);
+    destroy_da_mem(AT, ofibs, rank, -1);
+    AlignedFree(nViolations);
 
     wtime_s = omp_get_wtime();
     // Calculate the Log likelihood fit
@@ -1292,6 +1295,7 @@ cp_apr_alto(AltoTensor<LIT>* AT, KruskalModel* M, int max_iters, int max_inner_i
     for (int i = 0; i < iter; i++) {
         nTotalInner += nInnerIters[i];
     }
+    assert(nTotalInner > 0);
     FType obj = tt_logLikelihood(AT, M, eps_div_zero);
 
     // Calculate the Gram matrices of the factor matrices and
@@ -1359,12 +1363,16 @@ cp_apr_alto(AltoTensor<LIT>* AT, KruskalModel* M, int max_iters, int max_inner_i
             modeTimes[0], nmodes > 1 ? modeTimes[1] : 0, nmodes > 2 ? modeTimes[2] : 0, nmodes > 3 ? modeTimes[3] : 0,
             nmodes > 4 ? modeTimes[4] : 0, (wtime_pre + wtime_apr + wtime_post)/nTotalInner);
 
-    // for (int n = 0; n < nmodes; n++) {
-    //     AlignedFree(Phi[n]);
-    // }
-    // AlignedFree(Phi);
-
-    // if (needPhiPrecomp) AlignedFree(AT->precomp_row);
+    AlignedFree(modeTimes);
+    AlignedFree(nInnerItersPerMode);
+    AlignedFree(modePhiTimes);
+    AlignedFree(kktViolations);
+    AlignedFree(nInnerIters);
+    AlignedFree(tmp_mttkrp);
+    for (int n = 0; n < nmodes; n++) {
+        AlignedFree(tmp_grams[n]);
+    }
+    AlignedFree(tmp_grams);
 }
 
 #endif // APR_HPP_

--- a/include/apr.hpp
+++ b/include/apr.hpp
@@ -1,0 +1,1372 @@
+#ifndef APR_HPP_
+#define APR_HPP_
+
+#include "common.hpp"
+#include "sptensor.hpp"
+#include "kruskal_model.hpp"
+#include "alto.hpp"
+#include "omp.h"
+
+#define MIN_APR_REUSE 4
+#define OTF
+//#define PRE
+
+void cp_apr_mu_alto(SparseTensor* X,
+					KruskalModel* M,
+					int max_iters,
+					int max_inner_iters,
+					FType epsilon,
+					FType eps_div_zero,
+					FType kappa_tol,
+					FType kappa);
+
+void cp_apr_mu_alto_otf(SparseTensor* X,
+						KruskalModel* M,
+						int max_iters,
+						int max_inner_iters,
+						FType epsilon,
+						FType eps_div_zero,
+						FType kappa_tol,
+						FType kappa);
+
+template <typename LIT>
+static inline void
+cp_apr_alto(AltoTensor<LIT>* AT,
+				 KruskalModel* M,
+				 int max_iters,
+				 int max_inner_iters,
+				 FType epsilon,
+				 FType eps_div_zero,
+				 FType kappa_tol,
+				 FType kappa,
+                 bool dobench);
+
+
+template <typename LIT>
+static inline void
+CalculatePhi_alto_par(FType* Phi,
+							AltoTensor<LIT>* AT,
+							KruskalModel* M,
+							int target_mode,
+							FType eps_div_zero,
+                            FType **ofibs,
+                            IType rank,
+                            bool usePrecomp);
+
+template <typename LIT, typename ModeT, typename RankT>
+static inline void
+CalculatePhi_alto_da_mem_pull(FType* Phi,
+							AltoTensor<LIT>* AT,
+							KruskalModel* M,
+							int target_mode,
+							FType eps_div_zero,
+                            FType **ofibs,
+                            ModeT nmodes,
+                            RankT rank,
+                            bool usePrecomp);
+
+template <typename LIT, typename ModeT, typename RankT>
+static inline void
+CalculatePhi_alto_atomic_cr(FType* Phi,
+                            AltoTensor<LIT>* AT,
+                            KruskalModel* M,
+                            int target_mode,
+                            FType eps_div_zero,
+                            ModeT nmodes,
+                            RankT rank,
+                            bool usePrecomp);
+
+template <typename LIT, typename ModeT, typename RankT>
+static inline void
+CalculatePhi_alto_atomic(FType* Phi,
+                            AltoTensor<LIT>* AT,
+                            KruskalModel* M,
+                            int target_mode,
+                            FType eps_div_zero,
+                            ModeT nmodes,
+                            RankT rank,
+                            bool usePrecomp);
+
+
+template <typename LIT>
+static inline void
+CalculatePhi_alto_OTF_base(FType* Phi,
+							AltoTensor<LIT>* AT,
+							KruskalModel* M,
+							int target_mode,
+							FType eps_div_zero);
+
+template <typename LIT>
+FType tt_logLikelihood(AltoTensor<LIT>* AT,
+						KruskalModel* M,
+                        FType eps_div_zero);
+
+FType tt_logLikelihood(SparseTensor* X,
+						KruskalModel* M,
+                        FType eps_div_zero);
+
+double cpd_fit_(SparseTensor* X,
+				KruskalModel* M,
+				FType** grams,
+				FType* U_mttkrp);
+
+template <typename LIT>
+static inline void
+mttkrp_(AltoTensor<LIT>* X,
+			KruskalModel* M,
+			int mode,
+			FType* U_mttkrp);
+
+static inline void
+mttkrp_(SparseTensor* X,
+			KruskalModel* M,
+			int mode,
+			FType* U_mttkrp);
+
+
+template <typename LIT>
+static inline void
+mttkrp_(AltoTensor<LIT>* AT, KruskalModel* M, int mode, FType* U_mttkrp)
+{
+  // we only do one MTTKRP, therefore we go with the atomic update here
+  int const nprtn = AT->nprtn;
+  IType const nmodes = AT->nmode;
+  IType const rank = M->rank;
+
+  #pragma omp parallel for schedule(static,1)
+  for (int p = 0; p < nprtn; ++p) {
+    //local buffer
+    LIT ALTO_MASKS[MAX_NUM_MODES];
+    for (int n = 0; n < nmodes; ++n) {
+        ALTO_MASKS[n] = AT->mode_masks[n];
+    }
+
+    FType row[rank];
+
+    LIT* const idx = AT->idx;
+    ValType* const vals = AT->vals;
+    IType const nnz_s = AT->prtn_ptr[p];
+    IType const nnz_e = AT->prtn_ptr[p + 1];
+
+    for (IType i = nnz_s; i < nnz_e; ++i) {
+      ValType const val = vals[i];
+      LIT const alto_idx = idx[i];
+
+      #pragma omp simd
+      for (IType r = 0; r < rank; ++r) {
+          row[r] = (FType)val;
+      }
+
+      for (int m = 0; m < nmodes; ++m) {
+        if (m != mode) {
+#ifndef ALT_PEXT
+          IType const row_id = pext(alto_idx, ALTO_MASKS[m]);
+#else
+          IType const row_id = pext(alto_idx, ALTO_MASKS[m], AT->mode_pos[m]);
+#endif
+          #pragma omp simd
+          for (IType r = 0; r < rank; r++) {
+            row[r] *= M->U[m][row_id * rank + r];
+          }
+        }
+      }
+
+      // update destination row
+#ifndef ALT_PEXT
+      IType const row_id = pext(alto_idx, ALTO_MASKS[mode]);
+#else
+      IType const row_id = pext(alto_idx, ALTO_MASKS[mode], AT->mode_pos[mode]);
+#endif
+      for (IType r = 0; r < rank; ++r) {
+        #pragma omp atomic update
+        U_mttkrp[row_id * rank + r] += row[r];
+      }
+    } // nnzs
+  } // prtns
+}
+
+static inline void
+mttkrp_(SparseTensor* X, KruskalModel* M, int mode, FType* U_mttkrp)
+{
+  IType nmodes = X->nmodes;
+  IType nnz = X->nnz;
+  IType** cidx = X->cidx;
+  IType rank = M->rank;
+
+  FType row[rank];
+
+  for(IType i = 0; i < nnz; i++) {
+    // initialize temporary accumulator
+    for(IType r = 0; r < rank; r++) {
+      row[r] = X->vals[i];
+    }
+
+    // calculate mttkrp for the current non-zero
+    for(IType m = 0; m < nmodes; m++) {
+      if(m != mode) {
+        IType row_id = cidx[m][i];
+        for(IType r = 0; r < rank; r++) {
+          row[r] *= M->U[m][row_id * rank + r];
+        }
+      }
+    }
+
+    // update destination row
+    IType row_id = cidx[mode][i];
+    for(IType r = 0; r < rank; r++) {
+      // M->U[mode][row_id * rank + r] += row[r];
+	  U_mttkrp[row_id * rank + r] += row[r];
+    }
+  } // for each nonzero
+}
+
+
+template <typename LIT, typename MT, IType... Ranks>
+struct calcPhi_alto_rank_specializer;
+
+template <typename LIT, typename MT>
+struct calcPhi_alto_rank_specializer<LIT, MT, 0>
+{
+    void
+    operator()(FType* Phi, AltoTensor<LIT>* AT, KruskalModel* M, int target_mode, FType eps_div_zero, FType** ofibs, IType fib_reuse, IType rank, MT nmodes, bool usePrecomp)
+    {
+        if (fib_reuse <= MIN_FIBER_REUSE) {
+            // Use op_sched only if oidx is available
+            if (AT->is_oidx)
+                return CalculatePhi_alto_op_sched(Phi, AT, M, target_mode, eps_div_zero, nmodes, rank, usePrecomp);
+            if (AT->cr_masks[target_mode])
+                return CalculatePhi_alto_atomic_cr(Phi, AT, M, target_mode, eps_div_zero, nmodes, rank, usePrecomp);
+            return CalculatePhi_alto_atomic(Phi, AT, M, target_mode, eps_div_zero, nmodes, rank, usePrecomp);
+        }
+        else
+            return CalculatePhi_alto_da_mem_pull(Phi, AT, M, target_mode, eps_div_zero, ofibs, nmodes, rank, usePrecomp);
+    }
+};
+
+template <typename LIT, typename MT, IType Head, IType... Tail>
+struct calcPhi_alto_rank_specializer<LIT, MT, 0, Head, Tail...>
+{
+    void
+    operator()(FType* Phi, AltoTensor<LIT>* AT, KruskalModel* M, int target_mode, FType eps_div_zero, FType** ofibs, IType fib_reuse, IType rank, MT nmodes, bool usePrecomp)
+    {
+        if (rank == Head) {
+            using const_rank = std::integral_constant<IType, Head>;
+            if (fib_reuse <= MIN_FIBER_REUSE) {
+                // Use op_sched only if oidx is available
+                if (AT->is_oidx)
+                    return CalculatePhi_alto_op_sched(Phi, AT, M, target_mode, eps_div_zero, nmodes, const_rank(), usePrecomp);
+                if (AT->cr_masks[target_mode])
+                    return CalculatePhi_alto_atomic_cr(Phi, AT, M, target_mode, eps_div_zero, nmodes, const_rank(), usePrecomp);
+                return CalculatePhi_alto_atomic(Phi, AT, M, target_mode, eps_div_zero, nmodes, const_rank(), usePrecomp);
+            }
+            else
+                return CalculatePhi_alto_da_mem_pull(Phi, AT, M, target_mode, eps_div_zero, ofibs, nmodes, const_rank(), usePrecomp);
+        }
+        else
+            return calcPhi_alto_rank_specializer<LIT, MT, 0, Tail...>()(Phi, AT, M, target_mode, eps_div_zero, ofibs, fib_reuse, rank, nmodes, usePrecomp);
+    }
+};
+
+
+template <typename LIT, int... Modes>
+struct calcPhi_alto_mode_specializer;
+
+template <typename LIT>
+struct calcPhi_alto_mode_specializer<LIT, 0>
+{
+    void
+    operator()(FType* Phi, AltoTensor<LIT>* AT, KruskalModel* M, int target_mode, FType eps_div_zero, FType** ofibs, IType fib_reuse, IType rank, bool usePrecomp)
+    { calcPhi_alto_rank_specializer<LIT, int, ALTO_RANKS_SPECIALIZED>()(Phi, AT, M, target_mode, eps_div_zero, ofibs, fib_reuse, rank, AT->nmode, usePrecomp); }
+};
+
+template <typename LIT, int Head, int... Tail>
+struct calcPhi_alto_mode_specializer<LIT, 0, Head, Tail...>
+{
+    void
+    operator()(FType* Phi, AltoTensor<LIT>* AT, KruskalModel* M, int target_mode, FType eps_div_zero, FType** ofibs, IType fib_reuse, IType rank, bool usePrecomp)
+    {
+        if (AT->nmode == Head) {
+            using const_mode = std::integral_constant<int, Head>;
+            calcPhi_alto_rank_specializer<LIT, const_mode, ALTO_RANKS_SPECIALIZED>()(Phi, AT, M, target_mode, eps_div_zero, ofibs, fib_reuse, rank, const_mode(), usePrecomp);
+        }
+        else
+            calcPhi_alto_mode_specializer<LIT, 0, Tail...>()(Phi, AT, M, target_mode, eps_div_zero, ofibs, fib_reuse, rank, usePrecomp);
+    }
+};
+
+template <typename LIT>
+static inline void
+CalculatePhi_alto_par(FType* Phi, AltoTensor<LIT>* AT, KruskalModel* M, int target_mode, FType eps_div_zero, FType** ofibs, IType rank, bool usePrecomp)
+{
+    IType fib_reuse = AT->nnz / AT->dims[target_mode];
+    return calcPhi_alto_mode_specializer<LIT, ALTO_MODES_SPECIALIZED>()(Phi, AT, M, target_mode, eps_div_zero, ofibs, fib_reuse, rank, usePrecomp);
+}
+
+
+// NAIVE implementation for validation
+template <typename LIT>
+void CalculatePhi_alto_OTF_base(FType* Phi, AltoTensor<LIT>* AT, KruskalModel* M, int target_mode, FType eps_div_zero)
+{
+	// printf("in CalculatePhi_alto_OTF: %d\n", target_mode);
+    IType nmodes = AT->nmode;
+    IType nnz = AT->nnz;
+    IType rank = M->rank;
+    // IType** cidx = X->cidx;
+    ValType* vals = AT->vals;
+    FType** U = M->U;
+    FType* B = U[target_mode];
+    IType dim = AT->dims[target_mode];
+
+    LIT ALTO_MASKS[MAX_NUM_MODES];
+    for (int n = 0; n < nmodes; ++n) {
+        ALTO_MASKS[n] = AT->mode_masks[n];
+    }
+
+
+    // Initialize Phi to 0
+    for(IType i = 0; i < dim * rank; i++) {
+        Phi[i] = 0.0;
+    }
+
+    // temporary array to store the KRP
+    FType row[rank];
+
+    for(IType i = 0; i < nnz; i++) {
+        // IType row_index = cidx[target_mode][i];
+        LIT alto_idx = AT->idx[i];
+#ifndef ALT_PEXT
+		IType row_index = pext(alto_idx, ALTO_MASKS[target_mode]);
+#else
+		IType row_index = pext(alto_idx, ALTO_MASKS[target_mode],
+								AT->mode_pos[target_mode]);
+#endif
+
+        // For each non-zero element, calculate the required KRP
+        for(IType r = 0; r < rank; r++) {
+            row[r] = 1.0;
+        }
+
+        for(IType n = 0; n < nmodes; n++) {
+            if(n != target_mode) {
+                // IType row_index_n = cidx[n][i];
+#ifndef ALT_PEXT
+				IType row_index_n = pext(alto_idx, ALTO_MASKS[n]);
+#else
+				IType row_index_n = pext(alto_idx, ALTO_MASKS[n],
+											AT->mode_pos[n]);
+#endif
+
+                for(IType r = 0; r < rank; r++) {
+                    row[r] *= U[n][row_index_n * rank + r];
+                }
+            }
+        }
+
+        // Calculate B*KRP
+        FType v = 0.0;
+        for(IType r = 0; r < rank; r++) {
+            v += B[row_index * rank + r] * row[r];
+        }
+
+		// if(row_index == 0) printf("-- %f %f %f\n", vals[i], v, vals[i] / fmax(v, eps_div_zero));
+
+        // divide nnz by this value
+        v = (FType)vals[i] / fmax(v, eps_div_zero);
+
+        // scale KR (i.e., row) by this value (i.e., v), and update Phi
+        for(IType r = 0; r < rank; r++) {
+            Phi[row_index * rank + r] += v * row[r];
+        }
+    }
+}
+
+template <typename LIT, typename ModeT, typename RankT>
+static inline void
+CalculatePhi_alto_da_mem_pull(FType* Phi, AltoTensor<LIT>* AT, KruskalModel* M, int target_mode, FType eps_div_zero, FType** ofibs, ModeT nmodes, RankT rank, bool usePrecomp)
+{
+    // printf("in CalculatePhi_alto_da_mem_pull: %d\n", target_mode);
+    assert(nmodes == AT->nmode);
+    ValType* vals = AT->vals;
+    FType** U = M->U;
+    FType* B = U[target_mode];
+    IType dim = AT->dims[target_mode];
+
+    int const nprtn = AT->nprtn;
+    //printf("Mode %d, %d prtns\n", target_mode, nprtn);
+
+    #pragma omp parallel proc_bind(close)
+    {
+        //local buffer
+        LIT ALTO_MASKS[MAX_NUM_MODES];
+
+        for (int n = 0; n < nmodes; ++n) {
+            ALTO_MASKS[n] = AT->mode_masks[n];
+        }
+
+        #pragma omp for schedule(static, 1)
+        for (int p = 0; p < nprtn; ++p) {
+            // temporary array to store the KRP
+            FType *row;
+            if (!usePrecomp) {
+                row = (FType*) AlignedMalloc(rank*sizeof(FType));
+            }
+
+            FType* const out = ofibs[p];
+            Interval const intvl = AT->prtn_intervals[p * nmodes + target_mode];
+            IType const offset = intvl.start;
+            IType const stop = intvl.stop;
+
+            memset(out, 0, (stop - offset + 1) * rank * sizeof(FType));
+
+            IType const nnz_s = AT->prtn_ptr[p];
+            IType const nnz_e = AT->prtn_ptr[p + 1];
+
+            for (IType i = nnz_s; i < nnz_e; ++i) {
+                LIT alto_idx = AT->idx[i];
+#ifndef ALT_PEXT
+                IType const row_index = pext(alto_idx, ALTO_MASKS[target_mode]);
+#else
+                IType const row_index = pext(alto_idx, ALTO_MASKS[target_mode], AT->mode_pos[target_mode]);
+#endif
+                if (usePrecomp) {
+                    row = &AT->precomp_row[i * rank];
+                } else {
+                    // on-the-fly comp
+                    // For each non-zero element, calculate the required KRP
+                    for(IType r=0; r<rank; ++r) {
+                        row[r] = 1.0;
+                    }
+
+                    for(IType n=0; n<nmodes; ++n) {
+                        if(n != target_mode) {
+    #ifndef ALT_PEXT
+                            IType const row_index_n = pext(alto_idx, ALTO_MASKS[n]);
+    #else
+                            IType const row_index_n = pext(alto_idx, ALTO_MASKS[n], AT->mode_pos[n]);
+    #endif
+                            #pragma omp simd safelen(16)
+                            for(IType r=0; r<rank; ++r) {
+                                row[r] *= U[n][row_index_n * rank + r];
+                            }
+                        }
+                    }
+                } // usePrecomp
+
+                // /*// Calculate B*KRP
+                FType v = 0.0;
+                #pragma omp simd safelen(16)
+                for(IType r=0; r<rank; ++r) {
+                     v += B[row_index * rank + r] * row[r];
+                }
+
+				// if(row_index == 0) printf("<<< %f %f %f\n", vals[i], v, vals[i] / fmax(v, eps_div_zero));
+
+                // divide nnz by this value
+                v = (FType)vals[i] / fmax(v, eps_div_zero);
+
+                IType const row_index_o = row_index - offset;
+
+                // scale KR (i.e., row) by this value (i.e., v), and update out
+                #pragma omp simd safelen(16)
+                for(IType r = 0; r < rank; r++) {
+                    out[row_index_o * rank + r] += v * row[r];
+                }// */
+            } //nnzs
+            if (!usePrecomp) AlignedFree(row);
+        } // nprtn
+
+        // pull-based accumulation
+        #pragma omp for schedule(static)
+        for (IType i = 0; i < dim; ++i) {
+            #pragma omp simd
+            for (IType r = 0; r < rank; r++) {
+                Phi[i * rank + r] = 0.0;
+            }
+        	for (int p = 0; p < nprtn; p++) {
+                Interval const intvl = AT->prtn_intervals[p * nmodes + target_mode];
+                IType const offset = intvl.start;
+                IType const stop = intvl.stop;
+
+                if ((i >= offset) && (i <= stop)) {
+                    FType* const out = ofibs[p];
+                    IType const j = i - offset;
+                    #pragma omp simd
+                    for (IType r = 0; r < rank; r++) {
+                        Phi[i * rank + r] += out[j * rank + r];
+                    }
+                }
+            } //prtns
+        } // num_fibs
+    } // omp parallel
+}
+
+template <typename LIT, typename ModeT, typename RankT>
+static inline void
+CalculatePhi_alto_atomic(FType* Phi, AltoTensor<LIT>* AT, KruskalModel* M, int target_mode, FType eps_div_zero, ModeT nmodes, RankT rank, bool usePrecomp)
+{
+	//printf("in CalculatePhi_alto_atomic: %d\n", target_mode);
+    assert(nmodes == AT->nmode);
+    ValType* vals = AT->vals;
+    FType** U = M->U;
+    FType* B = U[target_mode];
+    IType dim = AT->dims[target_mode];
+
+    int const nprtn = AT->nprtn;
+    //printf("Mode %d, %d prtns\n", target_mode, nprtn);
+
+    #pragma omp parallel proc_bind(close)
+    {
+        //local buffer
+        LIT ALTO_MASKS[MAX_NUM_MODES];
+
+        for (int n = 0; n < nmodes; ++n) {
+            ALTO_MASKS[n] = AT->mode_masks[n];
+        }
+		#pragma omp for simd schedule(static)
+        for(IType i = 0; i < dim * rank; i++) {
+        	Phi[i] = 0.0;
+        }
+
+        #pragma omp for schedule(static, 1)
+        for (int p = 0; p < nprtn; ++p) {
+            // temporary array to store the KRP
+            FType *row;
+            if (!usePrecomp) {
+                row = (FType*) AlignedMalloc(rank * sizeof(FType));
+            }
+
+            IType const nnz_s = AT->prtn_ptr[p];
+            IType const nnz_e = AT->prtn_ptr[p + 1];
+
+            for (IType i = nnz_s; i < nnz_e; ++i) {
+                LIT alto_idx = AT->idx[i];
+#ifndef ALT_PEXT
+                IType const row_index = pext(alto_idx, ALTO_MASKS[target_mode]);
+#else
+                IType const row_index = pext(alto_idx, ALTO_MASKS[target_mode], AT->mode_pos[target_mode]);
+#endif
+                if (usePrecomp) {
+                    row = &AT->precomp_row[i * rank];
+                } else {
+                    // on-the-fly comp
+                    // For each non-zero element, calculate the required KRP
+                    for(IType r=0; r<rank; ++r) {
+                        row[r] = 1.0;
+                    }
+
+                    for(IType n=0; n<nmodes; ++n) {
+                        if(n != target_mode) {
+    #ifndef ALT_PEXT
+                            IType const row_index_n = pext(alto_idx, ALTO_MASKS[n]);
+    #else
+                            IType const row_index_n = pext(alto_idx, ALTO_MASKS[n], AT->mode_pos[n]);
+    #endif
+                            #pragma omp simd safelen(16)
+                            for(IType r=0; r<rank; ++r) {
+                                row[r] *= U[n][row_index_n * rank + r];
+                            }
+                        }
+                    }
+                } // usePrecomp
+
+                // /*// Calculate B*KRP
+                FType v = 0.0;
+                #pragma omp simd safelen(16)
+                for(IType r=0; r<rank; ++r) {
+                     v += B[row_index * rank + r] * row[r];
+                }
+
+				// if(row_index == 0) printf("<<< %f %f %f\n", vals[i], v, vals[i] / fmax(v, eps_div_zero));
+
+                // divide nnz by this value
+                v = (FType)vals[i] / fmax(v, eps_div_zero);
+
+                // scale KR (i.e., row) by this value (i.e., v), and update Phi atomically
+                for(IType r = 0; r < rank; r++) {
+                    #pragma omp atomic update
+                    Phi[row_index * rank + r] += v * row[r];
+                }
+            } //nnzs
+            if (!usePrecomp) AlignedFree(row);
+        } // nprtn
+    } // omp parallel
+}
+
+
+template <typename LIT, typename ModeT, typename RankT>
+static inline void
+CalculatePhi_alto_atomic_cr(FType* Phi, AltoTensor<LIT>* AT, KruskalModel* M, int target_mode, FType eps_div_zero, ModeT nmodes, RankT rank, bool usePrecomp)
+{
+	//printf("in CalculatePhi_alto_atomic_cr: %d\n", target_mode);
+    assert(nmodes == AT->nmode);
+    ValType* vals = AT->vals;
+    FType** U = M->U;
+    FType* B = U[target_mode];
+    IType dim = AT->dims[target_mode];
+
+    int const nprtn = AT->nprtn;
+    LIT const cr_mask = AT->cr_masks[target_mode];
+    //printf("Mode %d, %d prtns\n", target_mode, nprtn);
+
+    #pragma omp parallel proc_bind(close)
+    {
+        //local buffer
+        LIT ALTO_MASKS[MAX_NUM_MODES];
+
+        for (int n = 0; n < nmodes; ++n) {
+            ALTO_MASKS[n] = AT->mode_masks[n];
+        }
+		#pragma omp for simd schedule(static)
+        for(IType i = 0; i < dim * rank; i++) {
+        	Phi[i] = 0.0;
+        }
+
+        #pragma omp for schedule(static, 1)
+        for (int p = 0; p < nprtn; ++p) {
+            // temporary array to store the KRP
+            FType *row;
+            if (!usePrecomp) {
+                row = (FType*) AlignedMalloc(rank*sizeof(FType));
+            }
+
+            IType const nnz_s = AT->prtn_ptr[p];
+            IType const nnz_e = AT->prtn_ptr[p + 1];
+
+            for (IType i = nnz_s; i < nnz_e; ++i) {
+                LIT alto_idx = AT->idx[i];
+#ifndef ALT_PEXT
+                IType const row_index = pext(alto_idx, ALTO_MASKS[target_mode]);
+#else
+                IType const row_index = pext(alto_idx, ALTO_MASKS[target_mode], AT->mode_pos[target_mode]);
+#endif
+                if (usePrecomp) {
+                    row = &AT->precomp_row[i * rank];
+                } else {
+                    // on-the-fly comp
+                    // For each non-zero element, calculate the required KRP
+                    for(IType r=0; r<rank; ++r) {
+                        row[r] = 1.0;
+                    }
+
+                    for(IType n=0; n<nmodes; ++n) {
+                        if(n != target_mode) {
+    #ifndef ALT_PEXT
+                            IType const row_index_n = pext(alto_idx, ALTO_MASKS[n]);
+    #else
+                            IType const row_index_n = pext(alto_idx, ALTO_MASKS[n], AT->mode_pos[n]);
+    #endif
+                            #pragma omp simd safelen(16)
+                            for(IType r=0; r<rank; ++r) {
+                                row[r] *= U[n][row_index_n * rank + r];
+                            }
+                        }
+                    }
+                } // usePrecomp
+
+                // /*// Calculate B*KRP
+                FType v = 0.0;
+                #pragma omp simd safelen(16)
+                for(IType r=0; r<rank; ++r) {
+                     v += B[row_index * rank + r] * row[r];
+                }
+
+				// if(row_index == 0) printf("<<< %f %f %f\n", vals[i], v, vals[i] / fmax(v, eps_div_zero));
+
+                // divide nnz by this value
+                v = (FType)vals[i] / fmax(v, eps_div_zero);
+
+                // scale KR (i.e., row) by this value (i.e., v), and update Phi atomically
+                if (alto_idx & cr_mask) {
+                    for(IType r = 0; r < rank; r++) {
+                        #pragma omp atomic update
+                        Phi[row_index * rank + r] += v * row[r];
+                    }
+                } else {
+                    #pragma omp simd safelen(16)
+                    for(IType r = 0; r < rank; r++) {
+                        Phi[row_index * rank + r] += v * row[r];
+                    }
+                }
+            } //nnzs
+            if (!usePrecomp) AlignedFree(row);
+        } // nprtn
+    } // omp parallel
+}
+
+template <typename LIT, typename ModeT, typename RankT>
+static inline void
+CalculatePhi_alto_op_sched(FType* Phi, AltoTensor<LIT>* AT, KruskalModel* M, int target_mode, FType eps_div_zero, ModeT nmodes, RankT rank, bool usePrecomp)
+{
+	// printf("in CalculatePhi_alto_op_sched: %d\n", target_mode);
+    assert(nmodes == AT->nmode);
+    LIT* const idx = AT->idx;
+    ValType* vals = AT->vals;
+    IType* const mode_oidx = AT->oidx[target_mode];
+    FType** U = M->U;
+    FType* B = U[target_mode];
+    IType dim = AT->dims[target_mode];
+
+    int const nprtn = AT->nprtn;
+    //printf("Mode %d, %d prtns\n", target_mode, nprtn);
+
+    #pragma omp parallel proc_bind(close)
+    {
+        //local buffer
+        LIT ALTO_MASKS[MAX_NUM_MODES];
+
+        for (int n = 0; n < nmodes; ++n) {
+            ALTO_MASKS[n] = AT->mode_masks[n];
+        }
+
+        #pragma omp for schedule(static, 1)
+        for (int p = 0; p < nprtn; ++p) {
+            IType const nnz_s = AT->prtn_ptr[p];
+            IType const nnz_e = AT->prtn_ptr[p + 1];
+            IType last_row;
+#ifndef ALT_PEXT
+            last_row = pext(idx[mode_oidx[nnz_s]], ALTO_MASKS[target_mode]);
+#else
+            last_row = pext(idx[mode_oidx[nnz_s]], ALTO_MASKS[target_mode], AT->mode_pos[target_mode]);
+#endif
+            for (IType r = 0; r < rank; ++r) {
+                #pragma omp atomic write
+                Phi[last_row * rank + r] = 0.0;
+            }
+#ifndef ALT_PEXT
+            last_row = pext(idx[mode_oidx[nnz_e - 1]], ALTO_MASKS[target_mode]);
+#else
+            last_row = pext(idx[mode_oidx[nnz_e - 1]], ALTO_MASKS[target_mode], AT->mode_pos[target_mode]);
+#endif
+            for (IType r = 0; r < rank; ++r) {
+                #pragma omp atomic write
+                Phi[last_row * rank + r] = 0.0;
+            }
+        }
+        #pragma omp barrier
+
+        #pragma omp for schedule(static, 1)
+        for (int p = 0; p < nprtn; ++p) {
+            FType accum[rank]; //Allocate an auto array of variable size.
+            memset(accum, 0, rank * sizeof(FType));
+            // temporary array to store the KRP
+            FType *row;
+            if (!usePrecomp) {
+                row = (FType*) AlignedMalloc(rank*sizeof(FType));
+            }
+
+            IType const nnz_s = AT->prtn_ptr[p];
+            IType const nnz_e = AT->prtn_ptr[p + 1];
+            IType last_row;
+#ifndef ALT_PEXT
+            last_row = pext(idx[mode_oidx[nnz_s]], ALTO_MASKS[target_mode]);
+#else
+            last_row = pext(idx[mode_oidx[nnz_s]], ALTO_MASKS[target_mode], AT->mode_pos[target_mode]);
+#endif
+            bool is_boundry = true;
+
+            for (IType i = nnz_s; i < nnz_e; ++i) {
+                LIT const alto_idx = idx[mode_oidx[i]];
+                FType const val = (FType) vals[mode_oidx[i]];
+#ifndef ALT_PEXT
+                IType const row_index = pext(alto_idx, ALTO_MASKS[target_mode]);
+#else
+                IType const row_index = pext(alto_idx, ALTO_MASKS[target_mode], AT->mode_pos[target_mode]);
+#endif
+                if (usePrecomp) {
+                    row = &AT->precomp_row[i * rank];
+                } else {
+                    // on-the-fly comp
+                    // For each non-zero element, calculate the required KRP
+                    #pragma omp simd safelen(16)
+                    for(IType r=0; r<rank; ++r) {
+                        row[r] = 1.0;
+                    }
+
+                    for(IType n=0; n<nmodes; ++n) {
+                        if(n != target_mode) {
+    #ifndef ALT_PEXT
+                            IType const row_index_n = pext(alto_idx, ALTO_MASKS[n]);
+    #else
+                            IType const row_index_n = pext(alto_idx, ALTO_MASKS[n], AT->mode_pos[n]);
+    #endif
+                            #pragma omp simd safelen(16)
+                            for(IType r=0; r<rank; ++r) {
+                                row[r] *= U[n][row_index_n * rank + r];
+                            }
+                        }
+                    }
+                } // usePrecomp
+
+                // /*// Calculate B*KRP
+                FType v = 0.0;
+                #pragma omp simd safelen(16)
+                for(IType r=0; r<rank; ++r) {
+                     v += B[row_index * rank + r] * row[r];
+                }
+
+				// if(row_index == 0) printf("<<< %f %f %f\n", vals[i], v, vals[i] / fmax(v, eps_div_zero));
+
+                // divide nnz by this value
+                v = val / fmax(v, eps_div_zero);
+
+                // scale KR (i.e., row) by this value (i.e., v), and update Phi atomically
+                // flush when index changes
+                if(last_row != row_index) {
+                    if (is_boundry) { // use atomics
+                        for (IType r = 0; r < rank; ++r) {
+                            #pragma omp atomic update
+                            Phi[last_row * rank + r] += accum[r];
+                        }
+                        is_boundry = false;
+                    } else {
+                        #pragma omp simd safelen(16)
+                        for (IType r = 0; r < rank; ++r) {
+                            Phi[last_row * rank + r] = accum[r];
+                            // Phi[last_row * rank + r] += accum[r];
+                        }
+                    }
+                    memset(accum, 0, rank * sizeof(FType));
+                } // index changes
+                last_row = row_index;
+
+                #pragma omp simd safelen(16)
+                for (IType r = 0; r < rank; ++r) {
+                    accum[r] += v * row[r];
+                }
+
+                // write the very last updates
+                if (i == nnz_e - 1) {
+                    for (IType r = 0; r < rank; ++r) {
+                        #pragma omp atomic update
+                        Phi[last_row * rank + r] += accum[r];
+                    }
+                }
+            } //nnzs
+            if (!usePrecomp) AlignedFree(row);
+        } // nprtn
+    } // omp parallel
+}
+
+// Calculate the Log likelihood for the final decomposition
+template <typename LIT>
+FType tt_logLikelihood(AltoTensor<LIT>* AT, KruskalModel* M, FType eps_div_zero)
+{
+
+	int nmodes = AT->nmode;
+    IType nnz = AT->nnz;
+	IType rank = M->rank;
+	FType* lambda = M->lambda;
+	FType** U = M->U;
+
+    LIT* const idx = AT->idx;
+
+	// Absorb the lambda into the first mode
+	RedistributeLambda (M, 0);
+
+#if 0
+	// Initialize A
+	FType* A = (FType*) AlignedMalloc(nnz * rank * sizeof(FType));
+    #pragma omp parallel for simd schedule(static)
+	for(IType i = 0; i < nnz * rank; i++) {
+		A[i] = 1.0;
+	}
+
+	for(int n = 0; n < nmodes; n++) {
+		FType* U_n = U[n];
+        #pragma omp parallel for schedule(static)
+		for(IType i = 0; i < nnz; i++) {
+            LIT const alto_idx = idx[i];
+#ifndef ALT_PEXT
+            IType const row_index = pext(alto_idx, AT->mode_masks[n]) * rank;
+#else
+            IType const row_index = pext(alto_idx, AT->mode_masks[n], AT->mode_pos[n]) * rank;
+#endif
+            #pragma omp simd
+			for(IType r = 0 ; r < rank; r++) {
+				A[i * rank + r] = A[i * rank + r] * U_n[row_index + r];
+			}
+		}
+	}
+
+	FType logSum = 0.0;
+    #pragma omp parallel for schedule(static) reduction(+:logSum)
+	for(IType i = 0; i < nnz; i++) {
+		FType tmp = 0.0;
+        #pragma omp simd
+		for(IType r = 0; r < rank; r++) {
+			tmp += A[i * rank + r];
+		}
+        // TODO check if that's ok (to avoid -inf)
+        if (tmp < eps_div_zero)
+            tmp = eps_div_zero;
+   		logSum += (FType)AT->vals[i] * log(tmp);
+	}
+    AlignedFree(A);
+#else
+	// sum over all nonzeros
+	FType logSum = 0.0;
+	// scratchpad for calculating KRP for each nonzero
+	int num_threads = omp_get_max_threads();
+	FType** gscratch = (FType**) AlignedMalloc(sizeof(FType*) * num_threads);
+	assert(gscratch);
+    #pragma omp parallel for
+	for(int t = 0; t < num_threads; t++) {
+		gscratch[t] = (FType*) AlignedMalloc(sizeof(FType) * rank);
+		assert(gscratch[t]);
+	}
+
+    #pragma omp parallel
+	{
+		FType* scratch = gscratch[omp_get_thread_num()];
+		#pragma omp for schedule(static) reduction(+:logSum)
+		for(IType i = 0; i < nnz; i++) {
+			// initialize scratch to 1.0
+			#pragma omp simd
+			for(IType r = 0; r < rank; r++) {
+				scratch[r] = 1.0;
+			}
+
+			// Go through every mode and Hadmard product the i,j,k rows
+			LIT const alto_idx = idx[i];
+			for(int n = 0; n < nmodes; n++) {
+				FType* U_n = U[n];
+#ifndef ALT_PEXT
+	            IType const row_index = pext(alto_idx, AT->mode_masks[n]) * rank;
+#else
+	            IType const row_index = pext(alto_idx, AT->mode_masks[n], AT->mode_pos[n]) * rank;
+#endif
+				#pragma omp simd
+				for(IType r = 0; r < rank; r++) {
+					scratch[r] *= U_n[row_index + r];
+				}
+			}
+
+			FType tmp = 0.0;
+			// #pragma omp simd
+			for(IType r = 0; r < rank; r++) {
+				tmp += scratch[r];
+			}
+			if(tmp < eps_div_zero) {
+				tmp = eps_div_zero;
+			}
+			logSum += (FType) AT->vals[i] * log(tmp);
+		}
+	} // #pragma omp parallel
+    #pragma omp parallel for
+	for(int t = 0; t < num_threads; t++) {
+		AlignedFree(gscratch[t]);
+	}
+	AlignedFree(gscratch);
+#endif
+
+	FType factorSum = 0.0;
+    #pragma omp parallel for simd schedule(static) reduction(+:factorSum)
+	for(IType i = 0; i < AT->dims[0] * rank; i++) {
+		factorSum += U[0][i];
+	}
+
+	for(IType r = 0; r < rank; r++) {
+		FType temp = 0.0;
+        #pragma omp parallel for simd schedule(static) reduction(+:temp)
+		for(IType i = 0; i < AT->dims[0]; i++) {
+			temp += fabs (U[0][i * rank + r]);
+		}
+        #pragma omp parallel for simd schedule(static)
+		for(IType i = 0; i < AT->dims[0]; i++) {
+			U[0][i * rank + r] = U[0][i * rank + r] / temp;
+		}
+		lambda[r] = lambda[r] * temp;
+	}
+
+	return (logSum - factorSum);
+}
+
+template <typename LIT>
+static inline void
+cp_apr_alto(AltoTensor<LIT>* AT, KruskalModel* M, int max_iters, int max_inner_iters, FType epsilon, FType eps_div_zero, FType kappa_tol, FType kappa, bool dobench)
+{
+
+    // timers
+    double wtime_s, wtime_t;
+    double wtime_pre = 0.0;
+    double wtime_apr = 0.0;
+    double wtime_apr_phi = 0.0;
+    double wtime_post = 0.0;
+
+    fprintf(stdout, "Running ALTO CP-APR with: \n");
+    // max outer iterations
+    fprintf(stdout, "\tmax iters:           %d\n", max_iters);
+    // max inner iterations
+    fprintf(stdout, "\tmax inner iters:     %d\n", max_inner_iters);
+    // tolerance on the overall KKT violation
+    fprintf(stdout, "\ttolerance:           %.2e\n", epsilon);
+    // safeguard against divide by zero
+    fprintf(stdout, "\teps_div_zero:        %.2e\n", eps_div_zero);
+    // tolerance on complementary slackness
+    fprintf(stdout, "\tkappa_tol:           %.2e\n", kappa_tol);
+    // offset to fix complementary slackness
+    fprintf(stdout, "\tkappa:               %.2e\n", kappa);
+    // data type sizes
+    fprintf(stdout, "\tOrdinal Type:        int%lu\n", 8*sizeof(IType));
+    fprintf(stdout, "\tSparse Val Type:     %s%lu\n", typeid(ValType) == typeid(double) || typeid(ValType) == typeid(float) ? "FP" : "int", 8*sizeof(ValType));
+    fprintf(stdout, "\tKruskal Val Type:    FP%lu\n", 8*sizeof(FType));
+#ifdef OTF
+    fprintf(stdout, "\tPHI update mode:     OTF\n");
+#endif
+#ifdef PRE
+    fprintf(stdout, "\tPHI update mode:     PRE\n");
+#endif
+
+    wtime_s = omp_get_wtime();
+    // Tensor and factor matrices information
+    int nmodes = AT->nmode;
+    IType* dims = AT->dims;
+    IType rank = M->rank;
+    FType** U = M->U;
+    FType* lambda = M->lambda;
+    // LIT* idx = AT->idx;
+
+    IType nthreads = omp_get_max_threads();
+    // Create local fiber copies
+    FType ** ofibs = NULL;
+    create_da_mem(-1, rank, AT, &ofibs);
+
+    bool needPhiPrecomp = true;
+    for (int n=0; n<nmodes; ++n) {
+        IType fib_reuse = AT->nnz / AT->dims[n];
+        // So far, use the same threshold for deciding over pre-comp/on-the-fly-comp for Phi as for da_mem_pull/atomic approach choice
+        if (fib_reuse <= MIN_APR_REUSE) {
+            needPhiPrecomp = true;
+        }
+    }
+#ifdef OTF
+    needPhiPrecomp = false;
+#ifdef PRE
+    printf("Do not set both OTF and PRE. Exiting.\n");
+    exit(1);
+#endif
+#endif
+#ifdef PRE
+    needPhiPrecomp = true;
+#endif
+
+    // Intermediate matrices
+    // Phi matrix is an intermediate matrix equal in size to the factor matrix
+    FType** Phi = (FType**) AlignedMalloc(nmodes * sizeof(FType*));
+    assert(Phi);
+    for(int n = 0; n < nmodes; n++) {
+        Phi[n] = (FType*) AlignedMalloc(dims[n] * rank * sizeof(FType));
+        assert(Phi[n]);
+    }
+
+    // Used for keeping track of convergence information
+    FType* kktModeViolations = (FType*) AlignedMalloc(nmodes * sizeof(FType));
+    assert(kktModeViolations);
+    for(int n = 0; n < nmodes; n++) {
+        kktModeViolations[n] = 0.0;
+    }
+    int* nViolations = (int*) AlignedMalloc(max_iters * sizeof(int));
+    assert(nViolations);
+    for(int i = 0; i < max_iters; i++) {
+        nViolations[i] = 0;
+    }
+    FType* kktViolations = (FType*) AlignedMalloc(max_iters * sizeof(FType));
+    assert(kktViolations);
+    for(int i = 0; i < max_iters; i++) {
+        kktViolations[i] = 0.0;
+    }
+    int* nInnerIters = (int*) AlignedMalloc(max_iters * sizeof(int));
+    assert(nInnerIters);
+    for(int i = 0; i < max_iters; i++) {
+        nInnerIters[i] = 0;
+    }
+    int* nInnerItersPerMode = (int*) AlignedMalloc(nmodes * sizeof(int));
+    assert(nInnerItersPerMode);
+    double * modeTimes = (double*) AlignedMalloc(nmodes * sizeof(double));
+    assert(modeTimes);
+    double * modePhiTimes = (double*) AlignedMalloc(nmodes * sizeof(double));
+    assert(modePhiTimes);
+    for(int i = 0; i < nmodes; i++) {
+        nInnerItersPerMode[i] = 0;
+        modeTimes[i] = 0.0;
+        modePhiTimes[i] = 0.0;
+    }
+    int const nprtn = AT->nprtn;
+    if (needPhiPrecomp) {
+        AT->precomp_row = (FType*) AlignedMalloc(AT->nnz * rank * sizeof(FType));
+        assert(AT->precomp_row);
+    }
+
+    wtime_pre += omp_get_wtime() - wtime_s;
+
+
+    wtime_s = omp_get_wtime();
+    fprintf(stdout, "CP_APR ALTO (OTF): \n");
+    KruskalModelNormalize(M);
+    // Iterate until covergence or max_iters reached
+    int iter;
+    double wtime_mod = omp_get_wtime();
+    bool usePrecomp;
+    for(iter = 0; iter < max_iters; iter++) {
+        bool converged = false;
+        for(int n = 0; n < nmodes; n++) {
+            wtime_mod = omp_get_wtime();
+            IType dim = dims[n];
+            FType* B = U[n];
+            FType* Phi_n = Phi[n];
+
+            // based on re-use, do pre-computation or not
+            ////////////////////////////////////////////////
+            // EDIT HERE FOR A DIFFERENT HEURISTIC /////////
+            // 1) heuristic equal to differentiation between pull-based and atomic approach for each mode:
+            // IType fib_reuse = AT->nnz / AT->dims[n];
+            // usePrecomp = fib_reuse <= MIN_APR_REUSE; //MIN_FIBER_REUSE;
+            // 2) simple user-defined sttatic approach:
+#ifdef OTF
+            usePrecomp = false;
+#endif
+#ifdef PRE
+            usePrecomp = true;     // or true
+#endif
+            // 3) like 1), but the same for all modes:
+            //usePrecomp = needPhiPrecomp;
+            ////////////////////////////////////////////////
+            if (usePrecomp) {
+                wtime_t = omp_get_wtime();
+                // pre computation
+                #pragma omp parallel for schedule(static,1)
+                for (int p = 0; p < nprtn; ++p)
+                {
+                    Interval const intvl = AT->prtn_intervals[p * nmodes + n];
+                    IType const offset = intvl.start;
+                    IType const stop = intvl.stop;
+                    IType const nnz_s = AT->prtn_ptr[p];
+                    IType const nnz_e = AT->prtn_ptr[p + 1];
+
+                    for (IType i = nnz_s; i < nnz_e; ++i)
+                    {
+                        LIT alto_idx = AT->idx[i];
+                        for (IType r=0; r<rank; ++r) {
+                            AT->precomp_row[i * rank + r] = 1.0;
+                        }
+
+                        for (IType n_sub=0; n_sub<nmodes; ++n_sub) {
+                            if (n_sub != n) {
+#ifndef ALT_PEXT
+                                IType const row_index_n = pext(alto_idx, AT->mode_masks[n_sub]);
+#else
+                                IType const row_index_n = pext(alto_idx, AT->mode_masks[n_sub], AT->mode_pos[n_sub]);
+#endif
+#pragma omp simd safelen(16)
+                                for (IType r=0; r<rank; ++r) {
+                                    AT->precomp_row[i * rank + r] *= U[n_sub][row_index_n * rank + r];
+                                }
+                            }
+                        } // n_sub
+                    } // i
+                } // partition
+                double tmp = omp_get_wtime() - wtime_t;
+				wtime_apr_phi += tmp;
+                modePhiTimes[n] += tmp;
+            } // phi_precomp
+
+            // Lines 4-5 in Algorithm 3 of the CP-APR paper
+            // Calculate B <- (A^)n) + S) lambda
+            //TODO: optimize?
+            if(iter > 0) {
+                bool any_violation = false;
+
+                #pragma omp parallel for schedule(static) reduction(||:any_violation)
+                for(IType i = 0; i < dim * rank; i++) {
+                    if((B[i] < kappa_tol) && (Phi_n[i] > 1.0)) {
+                        B[i] += kappa;
+                        any_violation |= true;
+                    }
+                }
+                if(any_violation) {
+                    nViolations[iter]++;
+                }
+            }
+
+            // Redstribute Lambda
+            RedistributeLambda(M, n);
+
+            // Iterate until convergence or max_inner_iters reached
+            for(int inner = 0; inner < max_inner_iters; inner++) {
+				// printf("inner iter: %d\n", inner);
+                nInnerIters[iter]++;
+                nInnerItersPerMode[n]++;
+
+                wtime_t = omp_get_wtime();
+                // Line 8 in Algorithm 3 of the CP-APR paper
+                // Calculate Phi^(n)
+                // CalculatePhi_OTF(Phi_n, AT, M, n, eps_div_zero);
+				// CalculatePhi_alto_OTF_base(Phi_n, AT, M, n, eps_div_zero, ofibs);
+                CalculatePhi_alto_par(Phi_n, AT, M, n, eps_div_zero, ofibs, rank, usePrecomp);
+
+                double tmp = omp_get_wtime() - wtime_t;
+				wtime_apr_phi += tmp;
+                modePhiTimes[n] += tmp;
+                // Line 9-11 in Algorithm 3 of the CP-APR paper
+                // Check for convergence
+                FType kkt_violation = 0.0;
+                #pragma omp parallel for schedule(static) reduction(max:kkt_violation)
+                for(IType i = 0; i < dim * rank; i++) {
+                    FType min_comp = fabs(fmin(B[i], 1.0 - Phi_n[i]));
+                    kkt_violation = fmax(kkt_violation, min_comp);
+                }
+                kktModeViolations[n] = kkt_violation;
+                // calculate kkt_violation
+                if ((kkt_violation < epsilon) && !dobench) {
+                    break;
+                } else {
+                    converged = false;
+                }
+
+                // Line 13 in Algorithm 3 of the CP-APR paper
+                // Do the multiplicative update
+                #pragma omp parallel for simd schedule(static)
+                for (IType i = 0; i < dim * rank; i++) {
+                    B[i] *= Phi_n[i];
+                }
+
+                /*
+                if (inner % 1 == 0) {
+                    fprintf (stdout, "\tMode = %d, Inner iter = %d, ",
+                             n, inner);
+                    fprintf (stdout, " KKT violation == %.6e\n",
+                             kktModeViolations[n]);
+                }
+                 */
+            } // for (int inner = 0; inner < max_inner_iters; inner++)
+
+            // Line 15-16 in Algorithm 3 of the CP-APR paper
+            // Shift weights from mode n back to Lambda and update A^(n)
+            // Basically, KruskalModelNormalize for only mode n
+            KruskalModelNormalizeMode(M, n);
+            modeTimes[n] += (omp_get_wtime() - wtime_mod);
+        } // for (int n = 0; n < nmodes; n++)
+
+
+        kktViolations[iter] = kktModeViolations[0];
+        for (int n = 1; n < nmodes; n++) {
+            kktViolations[iter] = fmax(kktViolations[iter],
+                                        kktModeViolations[n]);
+        }
+        if ((iter % 10) == 0) {
+            fprintf (stdout, "Iter %d: Inner its = %d KKT violation = %.6e, ",
+                        iter, nInnerIters[iter], kktViolations[iter]);
+            fprintf (stdout, "nViolations = %d\n", nViolations[iter]);
+        }
+        if ((std::abs(kktViolations[iter] - kktViolations[iter-1]) <= epsilon*epsilon) && !dobench) {
+            converged = true;
+            fprintf (stdout, "Iter %d: Inner its = %d KKT violation = %.6e, ",
+                        iter, nInnerIters[iter], kktViolations[iter]);
+            fprintf (stdout, "nViolations = %d\n", nViolations[iter]);
+            printf("ErrorNorm delta below threshold. Assume convergence\n");
+        }
+
+
+        if (converged) {
+            fprintf(stdout, "Exiting since all subproblems reached KKT tol\n");
+            break;
+        }
+        if (iter == max_iters - 1) {
+            fprintf (stdout, "Iter %d: Inner its = %d KKT violation = %.6e, ",
+                        iter, nInnerIters[iter], kktViolations[iter]);
+            fprintf (stdout, "nViolations = %d\n", nViolations[iter]);
+
+        }
+    } // for(iter = 0; iter < max_iters; iter++)
+    wtime_apr += omp_get_wtime() - wtime_s;
+
+    for (int n = 0; n < nmodes; n++) {
+        AlignedFree(Phi[n]);
+    }
+    AlignedFree(Phi);
+    if (needPhiPrecomp) AlignedFree(AT->precomp_row);
+
+    wtime_s = omp_get_wtime();
+    // Calculate the Log likelihood fit
+    int nTotalInner = 0;
+    for (int i = 0; i < iter; i++) {
+        nTotalInner += nInnerIters[i];
+    }
+    FType obj = tt_logLikelihood(AT, M, eps_div_zero);
+
+    // Calculate the Gram matrices of the factor matrices and
+    // last mode's MTTKRP
+    // Then use cpd_fit to calculate the fit - this should give you the
+    // least-squares fit
+    FType** tmp_grams = (FType**) AlignedMalloc(nmodes * sizeof(FType*));
+    assert(tmp_grams);
+    for (int n = 0; n < nmodes; n++) {
+        tmp_grams[n] = (FType*) AlignedMalloc(rank * rank * sizeof(FType));
+        assert(tmp_grams[n]);
+    }
+    for (int n = 0; n < nmodes; n++) {
+        update_gram(tmp_grams[n], M, n);
+    }
+
+    FType* tmp_mttkrp = (FType*) AlignedMalloc(dims[nmodes - 1] * rank *
+                                                sizeof(FType));
+    assert(tmp_mttkrp);
+    for(IType i = 0; i < dims[nmodes - 1] * rank; i++) {
+        tmp_mttkrp[i] = 0.0;
+    }
+    mttkrp_(AT, M, nmodes - 1, tmp_mttkrp);
+    // Compute ttnormsq to later compute fit
+    FType normAT = 0.0;
+    ValType* vals = AT->vals;
+    IType nnz = AT->nnz;
+    #pragma omp parallel for reduction(+:normAT) schedule(static)
+    for (IType i = 0; i < nnz; ++i) {
+        normAT += (FType)vals[i] * (FType)vals[i];
+    }
+    double fit = cpd_fit_alto(AT, M, tmp_grams, tmp_mttkrp, normAT);
+    wtime_post += omp_get_wtime() - wtime_s;
+
+    fprintf(stdout, "  Final log-likelihood = %e\n", obj);
+    fprintf(stdout, "  Final least squares fit = %e\n", fit);
+    fprintf(stdout, "  Final KKT violation = %7.7e\n", kktViolations[iter-1]);
+    fprintf(stdout, "  Total outer iterations = %d\n", iter);
+    fprintf(stdout, "  Total inner iterations = %d\n", nTotalInner);
+
+    fprintf(stdout, "CP-APR pre-processing time  = %f (s)\n", wtime_pre);
+    fprintf(stdout, "CP-APR main iteration time  = %f (s)\n", wtime_apr);
+    for (int i=0; i<nmodes; ++i)
+        fprintf(stdout, "\tTime Mode %d = %f (s)\n", i, modeTimes[i]);
+    fprintf(stdout, "CP-APR Phi accumulated time = %f (s)\n", wtime_apr_phi);
+    for (int i=0; i<nmodes; ++i)
+        fprintf(stdout, "\tPhi Time Mode %d = %f (s)\n", i, modePhiTimes[i]);
+    fprintf(stdout, "CP-APR post-processing time = %f (s)\n", wtime_post);
+    fprintf(stdout, "CP-APR TOTAL time           = %f (s)\n",
+            wtime_pre + wtime_apr + wtime_post);
+
+    fprintf(stdout, "Time per iteration          = %f (s)\n",
+            (wtime_pre + wtime_apr + wtime_post)/nTotalInner);
+
+    fprintf(stdout, "%f,%f,%.2f,%f,%f,%f,%f,%f,%f,%f,%d,%d,%d,%d,%d,%d,%d,%e,%e,%e,%d,%d,%s,%f\n",
+            wtime_pre, wtime_apr, 0.0, wtime_apr_phi, wtime_post,
+            modeTimes[0], nmodes > 1 ? modeTimes[1] : 0, nmodes > 2 ? modeTimes[2] : 0,
+            nmodes > 3 ? modeTimes[3] : 0, nmodes > 4 ? modeTimes[4] : 0,
+            iter, nTotalInner, nInnerItersPerMode[0], nInnerItersPerMode[1],
+            nInnerItersPerMode[2], nmodes > 3 ? nInnerItersPerMode[3] : 0, nmodes > 4 ? nInnerItersPerMode[4] : 0,
+            obj, fit, kktViolations[iter-1], max_iters, max_inner_iters,
+            needPhiPrecomp ? "pre" : needPhiPrecomp ? "dyn" : "otf",
+            (wtime_pre + wtime_apr + wtime_post)/nTotalInner);
+    //printf("%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f\n", (wtime_pre + wtime_apr + wtime_post)/nTotalInner, modeTimes[0], modeTimes[0]/nTotalInner,
+    //                                                modeTimes[1], modeTimes[1]/nTotalInner, modeTimes[2], modeTimes[2]/nTotalInner,
+    //                                                modeTimes[3], modeTimes[3]/nTotalInner, modeTimes[4], modeTimes[4]/nTotalInner,
+    //                                                );
+
+    // for (int n = 0; n < nmodes; n++) {
+    //     AlignedFree(Phi[n]);
+    // }
+    // AlignedFree(Phi);
+
+    // if (needPhiPrecomp) AlignedFree(AT->precomp_row);
+}
+
+#endif // APR_HPP_
+

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -11,7 +11,8 @@
 #include <inttypes.h>
 #include <float.h>
 #include <sys/mman.h>
-#ifdef USE_MKL_
+//#ifdef USE_MKL_
+#ifdef MKL
 #include <mkl.h>
 #endif
 #ifdef USE_ESSL_
@@ -33,24 +34,46 @@
 // set the PRE_ALLOC[_ALTO] definitions in main.c and alto.c accordingly for the general
 // usage of hugepages
 
-typedef unsigned long long IType;
-#if 1
-typedef double FType;
-#define POTRF  dpotrf_
-#define POTRS  dpotrs_
-#define GELSY  dgelsy_
-#define SYRK   cblas_dsyrk
+
+// Ordinal Type
+#ifdef IDX_TYPE32
+  typedef unsigned int IType;
 #else
-typedef float FType;
-#define POTRF  spotrf
-#define POTRS  spotrs
-#define GELSY  sgelsy
-#define SYRK   cblas_ssyrk
+  typedef unsigned long long IType;
+#endif
+
+// Floating Point Type - used, e.g., for Kruskal tensors
+#ifdef FP_TYPE32
+  typedef float FType;
+  #define POTRF  spotrf
+  #define POTRS  spotrs
+  #define GELSY  sgelsy
+  #define SYRK   cblas_ssyrk
+#else
+  typedef double FType;
+  #define POTRF  dpotrf_
+  #define POTRS  dpotrs_
+  #define GELSY  dgelsy_
+  #define SYRK   cblas_dsyrk
+#endif
+
+
+// Value Type
+#ifdef VAL_TYPE_INT32
+  // use an integer type for count data
+  typedef uint32_t ValType;
+#elif VAL_TYPE_INT64
+  typedef unsigned long long ValType;
+#else
+  typedef FType ValType;
 #endif
 
 #define CACHELINE      64
 
 #define ROW 1
+
+typedef enum Model_ { ALS, APR } Model;
+
 
 inline uint64_t ReadTSC(void)
 {
@@ -212,4 +235,5 @@ double ElapsedTime(uint64_t ticks);
 void PrintFPMatrix(char *name, FType * a, size_t m, size_t n);
 
 void PrintIntMatrix(char *name, size_t * a, size_t m, size_t n);
+
 #endif // COMMON_HPP_

--- a/include/cpd.hpp
+++ b/include/cpd.hpp
@@ -381,7 +381,7 @@ double cpd_fit(SparseTensor* X, KruskalModel* M, FType** grams, FType* U_mttkrp)
 
   FType* accum = (FType*) AlignedMalloc(sizeof(FType) * rank);
   assert(accum);
-  memset(accum, 0, sizeof(FType*) * rank);
+  memset(accum, 0, sizeof(FType) * rank);
   #if 0
   for(IType i = 0; i < dims[nmodes - 1]; i++) {
     for(IType j = 0; j < rank; j++) {
@@ -632,7 +632,7 @@ static void pseudo_inverse(FType** grams, KruskalModel* M, IType mode)
     GELSY(&_rank, &_rank, &I, grams[mode], &_rank, M->U[mode], &_rank,
           jpvt, &rcond, &ret_rank, work, &lwork, &info_dgelsy);
 
-    fprintf(stderr, "\t Mode %llu Min Norm Solve: %d\nDGELSS effective rank: %d\n", mode, info_dgelsy, ret_rank);
+    fprintf(stderr, "\t Mode %llu Min Norm Solve: %d\nDGELSS effective rank: %d\n", mode, (int) info_dgelsy, (int) ret_rank);
     free(work);
     free(jpvt);
   }

--- a/include/kruskal_model.hpp
+++ b/include/kruskal_model.hpp
@@ -23,9 +23,10 @@ typedef enum
 void CreateKruskalModel(int mode, IType *dim, IType rank, KruskalModel **M_);
 
 void KruskalModelNormalize(KruskalModel *M);
+void KruskalModelNormalizeMode(KruskalModel *M, int n);
 
 void KruskalModelNorm(KruskalModel* M,
-                         IType mode, 
+                         IType mode,
                          mat_norm_type which,
                          FType ** scratchpad);
 
@@ -37,7 +38,10 @@ void DestroyKruskalModel(KruskalModel *M);
 
 void PrintKruskalModel(KruskalModel *M);
 
-void RedistributeLambda (KruskalModel *M, int n);
+void RedistributeLambda(KruskalModel *M, int n);
 
 double KruskalTensorFit();
+
+void update_gram(FType* gram, KruskalModel* M, int mode);
+
 #endif // KRUSKAL_MODEL_HPP_

--- a/include/rng_stream.hpp
+++ b/include/rng_stream.hpp
@@ -3,16 +3,26 @@
 
 
 #include "common.hpp"
-
+#include "rng.hpp"
 
 void CreateRNGStream(uint64_t seed, void **stream);
 
 void DestroyRNGStream(void *stream);
 
+template <typename FType>
 void RNGStreamUniform(void * stream, double low, double high,
-                      size_t len_v, double *v);
+                      size_t len_v, FType *v);
 
 void RNGStream64(void * stream, size_t len_v, uint64_t *v);
 
+template <typename FType>
+void RNGStreamUniform(void * stream, double low, double high,
+                      size_t len_v, FType *v)
+{
+	RNG *rng = (RNG *)stream;
+    for (size_t i = 0; i < len_v; i++) {
+        v[i] = (FType)rng_randfp64(rng) * (high - low) + low;
+    }
+}
 
 #endif // RNG_STREAM_HPP_

--- a/include/sptensor.hpp
+++ b/include/sptensor.hpp
@@ -9,7 +9,7 @@ struct sptensor_struct {
   // number of modes/dimensions in the tensor
   int nmodes;
 
-  // array that stores the length of each mode 
+  // array that stores the length of each mode
   IType* dims;
 
   // number of non-zeros
@@ -33,16 +33,16 @@ typedef enum FileFormat_
 
 void ExportSparseTensor(const char *file_path, FileFormat f, SparseTensor *X);
 
-void ImportSparseTensor(const char *file_path, FileFormat f, SparseTensor **X_);
+void ImportSparseTensor(const char *file_path, FileFormat f, SparseTensor **X_, IType zero_based);
 
 void DestroySparseTensor(SparseTensor *X);
 
 void CreateSparseTensor(
-  IType mode, 
-  IType* dims, 
+  IType mode,
+  IType* dims,
   IType nnz,
-  IType* cidx, 
-  FType* vals, 
+  IType* cidx,
+  FType* vals,
   SparseTensor** X_
 );
 

--- a/mk/include_ICC.mk
+++ b/mk/include_ICC.mk
@@ -4,11 +4,11 @@ LINKER   = $(CC)
 OPENMP   = -qopenmp
 ifeq ($(BLAS_LIBRARY),MKL)
 BLASLFLAGS 	= -mkl=parallel
-INCLUDFLAGS	= 
+INCLUDEFLAGS=
 BLASLIBS 	= -liomp5 -lpthread -lm -ldl #-lmkl_intel_lp64 #-lmkl_intel_thread
 else
 BLASLFLAGS 	= 
-INCLUDFLAGS	= 
+INCLUDEFLAGS=
 BLASLIBS 	= -lopenblas
 endif
 

--- a/src/apr.cpp
+++ b/src/apr.cpp
@@ -1,0 +1,763 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#include <assert.h>
+#include <time.h>
+#include <omp.h>
+
+#include "apr.hpp"
+#include "alto.hpp"
+
+double cpd_fit_(SparseTensor* X, KruskalModel* M, FType** grams, FType* U_mttkrp)
+{
+  // Calculate inner product between X and M
+  // This can be done via sum(sum(P.U{dimorder(end)} .* U_mttkrp) .* lambda');
+  IType rank = M->rank;
+  IType nmodes = X->nmodes;
+  IType* dims = X->dims;
+
+  FType* accum = (FType*) AlignedMalloc(sizeof(FType) * rank);
+  assert(accum);
+  memset(accum, 0, sizeof(FType) * rank);
+  #pragma omp parallel for schedule(static)
+  for(IType j = 0; j < rank; j++) {
+    for(IType i = 0; i < dims[nmodes - 1]; i++) {
+      accum[j] += M->U[nmodes - 1][i * rank + j] * U_mttkrp[i * rank + j];
+    }
+  }
+
+  FType inner_prod = 0.0;
+  for(IType i = 0; i < rank; i++) {
+    inner_prod += accum[i] * M->lambda[i];
+  }
+
+  // Calculate norm(X)^2
+  IType nnz = X->nnz;
+  FType* vals = X->vals;
+  FType normX = 0.0;
+  #pragma omp parallel for reduction(+:normX) schedule(static)
+  for(IType i = 0; i < nnz; i++) {
+    normX += vals[i] * vals[i];
+  }
+
+  // Calculate norm of factor matrices
+  // This can be done via taking the hadamard product between all the gram
+  // matrices, and then summing up all the elements and taking the square root
+  // of the absolute value
+  FType* tmp_gram = (FType*) AlignedMalloc(sizeof(FType) * rank * rank);
+  assert(tmp_gram);
+  #pragma omp parallel for schedule(dynamic)
+  for(IType i = 0; i < rank; i++) {
+    for(IType j = 0; j < i + 1; j++) {
+      tmp_gram[i * rank + j] = M->lambda[i] * M->lambda[j];
+    }
+  }
+
+  // calculate the hadamard product between all the Gram matrices
+  for(IType i = 0; i < nmodes; i++) {
+    #pragma omp parallel for schedule(dynamic)
+    for(IType j = 0; j < rank; j++) {
+      for(IType k = 0; k < j + 1; k++) {
+        tmp_gram[j * rank + k] *= grams[i][j * rank + k];
+      }
+    }
+  }
+
+  FType normU = 0.0;
+  for(IType i = 0; i < rank; i++) {
+    for(IType j = 0; j < i; j++) {
+      normU += tmp_gram[i * rank + j] * 2;
+    }
+    normU += tmp_gram[i * rank + i];
+  }
+  normU = fabs(normU);
+
+  // Calculate residual using the above
+  FType norm_residual = normX + normU - 2 * inner_prod;
+  if (norm_residual > 0.0) {
+    norm_residual = sqrt(norm_residual);
+  }
+  FType ret = 1 - (norm_residual / sqrt(normX));
+
+  // free memory
+  free(accum);
+  free(tmp_gram);
+
+  return ret;
+}
+
+
+/*
+static void update_gram(FType* gram, KruskalModel* M, int mode)
+{
+  MKL_INT m = M->dims[mode];
+  MKL_INT n = M->rank;
+  MKL_INT lda = n;
+  MKL_INT ldc = n;
+  FType alpha = 1.0;
+  FType beta = 0.0;
+
+  CBLAS_ORDER layout = CblasRowMajor;
+  CBLAS_UPLO uplo = CblasLower;
+  CBLAS_TRANSPOSE trans = CblasTrans;
+  SYRK(layout, uplo, trans, n, m, alpha, M->U[mode], lda, beta, gram, ldc);
+}
+ */
+
+// Calculate the Log likelihood for the final decomposition
+FType tt_logLikelihood(SparseTensor* X, KruskalModel* M, FType eps_div_zero)
+{
+
+	int nmodes = X->nmodes;
+	IType rank = M->rank;
+	FType* lambda = M->lambda;
+	FType** U = M->U;
+
+	// Absorb the lambda into the first mode
+	RedistributeLambda (M, 0);
+
+	// Initialize A
+	FType* A = (FType*) AlignedMalloc(X->nnz * rank * sizeof(FType));
+    #pragma omp parallel for simd schedule(static)
+	for(IType i = 0; i < X->nnz * rank; i++) {
+		A[i] = 1.0;
+	}
+
+	for(int n = 0; n < nmodes; n++) {
+		FType* U_n = U[n];
+        #pragma omp parallel for schedule(static)
+		for(IType i = 0; i < X->nnz; i++) {
+			IType row_index = X->cidx[n][i];
+            #pragma omp simd
+			for(IType r = 0 ; r < rank; r++) {
+				A[i * rank + r] = A[i * rank + r] * U_n[row_index* rank + r];
+			}
+		}
+	}
+
+	FType logSum = 0.0;
+    #pragma omp parallel for schedule(static) reduction(+:logSum)
+	for(IType i = 0; i < X->nnz; i++) {
+		FType tmp = 0.0;
+        #pragma omp simd
+		for(IType r = 0; r < rank; r++) {
+			tmp += A[i * rank + r];
+		}
+        if (tmp < eps_div_zero)
+            tmp = eps_div_zero;
+		logSum += X->vals[i] * log(tmp);
+	}
+
+	FType factorSum = 0.0;
+    #pragma omp parallel for simd schedule(static) reduction(+:factorSum)
+	for(IType i = 0; i < X->dims[0] * rank; i++) {
+		factorSum += U[0][i];
+	}
+
+
+	for(IType r = 0; r < rank; r++) {
+		FType temp = 0.0;
+        #pragma omp parallel for simd schedule(static) reduction(+:temp)
+		for(IType i = 0; i < X->dims[0]; i++) {
+			temp += fabs (U[0][i * rank + r]);
+		}
+        #pragma omp parallel for simd schedule(static)
+		for(IType i = 0; i < X->dims[0]; i++) {
+			U[0][i * rank + r] = U[0][i * rank + r] / temp;
+		}
+		lambda[r] = lambda[r] * temp;
+	}
+
+	return (logSum - factorSum);
+}
+
+
+void CalculatePhi(FType* Phi, FType* Pi, SparseTensor* X, KruskalModel* M, int target_mode, FType eps_div_zero)
+{
+	IType nnz = X->nnz;
+	IType rank = M->rank;
+	IType** cidx = X->cidx;
+	FType* vals = X->vals;
+	FType** U = M->U;
+	FType* B = U[target_mode];
+	IType dim = X->dims[target_mode];
+
+	// Initialize Phi to 0
+	for(IType i = 0; i < dim * rank; i++) {
+		Phi[i] = 0.0;
+	}
+
+	for(IType i = 0; i < nnz; i++) {
+		IType row_index = cidx[target_mode][i];
+		// dot-product between B and Pi, then compare to eps_div_zero
+		FType v = 0.0;
+		for(IType r = 0; r < rank; r++) {
+			v += B[row_index * rank + r] * Pi[i * rank + r];
+		}
+		// divide nnz by this value
+		v = vals[i] / fmax(v, eps_div_zero);
+
+		// scale KR (i.e., Pi) by this value (i.e., v), and update Phi
+		for(IType r = 0; r < rank; r++) {
+			Phi[row_index * rank + r] += v * Pi[i * rank + r];
+		}
+	}
+}
+
+
+void CalculatePi(FType* Pi, SparseTensor* X, KruskalModel* M, int target_mode)
+{
+	IType nnz = X->nnz;
+	IType rank = M->rank;
+	int nmodes = X->nmodes;
+	IType** cidx = X->cidx;
+	FType** U = M->U;
+
+	for(IType i = 0; i < nnz; i++) {
+		// Initialize Pi to 1.0 for Hadamard product
+		for(IType r = 0; r < rank; r++) {
+			Pi[i * rank + r] = 1.0;
+		}
+
+		// Calculate Pi for each non-zero element
+		for(int n = 0; n < nmodes; n++) {
+			if(n != target_mode) {
+				FType* A = U[n];
+				IType row_index = cidx[n][i];
+				for(IType r = 0; r < rank; r++) {
+					Pi[i * rank + r] *= A[row_index * rank + r];
+				}
+			}
+		}
+	}
+
+}
+
+
+void cp_apr_mu_alto(SparseTensor* X, KruskalModel* M, int max_iters, int max_inner_iters, FType epsilon, FType eps_div_zero, FType kappa_tol, FType kappa)
+{
+	// timers
+	double wtime_s, wtime_t;
+	double wtime_pre = 0.0;
+	double wtime_apr = 0.0;
+	double wtime_apr_pi = 0.0;
+	double wtime_apr_phi = 0.0;
+	double wtime_post = 0.0;
+
+	fprintf(stdout, "Running ALTO CP-APR with: \n");
+	// max outer iterations
+	fprintf(stdout, "\tmax iters:       %d\n", max_iters);
+	// max inner iterations
+	fprintf(stdout, "\tmax inner iters: %d\n", max_inner_iters);
+	// tolerance on the overall KKT violation
+	fprintf(stdout, "\ttolerance:       %.2e\n", epsilon);
+	// safeguard against divide by zero
+	fprintf(stdout, "\teps_div_zero:    %.2e\n", eps_div_zero);
+	// tolerance on complementary slackness
+	fprintf(stdout, "\tkapp_tol:        %.2e\n", kappa_tol);
+	// offset to fix complementary slackness
+	fprintf(stdout, "\tkapp:            %.2e\n", kappa);
+
+
+	wtime_s = omp_get_wtime();
+	// Tensor and factor matrices information
+	int nmodes = X->nmodes;
+	IType nnz = X->nnz;
+	IType* dims = X->dims;
+	IType rank = M->rank;
+	FType** U = M->U;
+	FType* lambda = M->lambda;
+
+	// Intermediate matrices
+	// Phi matrix is an intermediate matrix equal in size to the factor matrix
+	FType** Phi = (FType**) AlignedMalloc(nmodes * sizeof(FType*));
+	assert(Phi);
+	for(int n = 0; n < nmodes; n++) {
+		Phi[n] = (FType*) AlignedMalloc(dims[n] * rank * sizeof(FType));
+		assert(Phi[n]);
+	}
+	// Pi matrix is the Khatri-Rap product between every OTHER factor matrix
+	// Since it's extremely large, we do not compute it expliclity.
+	// Instead, we calculate the required KR product for each non-zero element.
+	// Thus, this Pi matrix is a nnz x R matrix
+	FType* Pi = (FType*) AlignedMalloc(nnz * rank * sizeof(FType));
+	assert(Pi);
+
+
+	// Used for keeping track of convergence information
+	FType* kktModeViolations = (FType*) AlignedMalloc(nmodes * sizeof(FType));
+	assert(kktModeViolations);
+	for(int n = 0; n < nmodes; n++) {
+		kktModeViolations[n] = 0.0;
+	}
+	int* nViolations = (int*) AlignedMalloc(max_iters * sizeof(int));
+	assert(nViolations);
+	for(int i = 0; i < max_iters; i++) {
+		nViolations[i] = 0;
+	}
+	FType* kktViolations = (FType*) AlignedMalloc(max_iters * sizeof(FType));
+	assert(kktViolations);
+	for(int i = 0; i < max_iters; i++) {
+		kktViolations[i] = 0.0;
+	}
+	int* nInnerIters = (int*) AlignedMalloc(max_iters * sizeof(int));
+	assert(nInnerIters);
+	for(int i = 0; i < max_iters; i++) {
+		nInnerIters[i] = 0;
+	}
+	wtime_pre += omp_get_wtime() - wtime_s;
+
+
+	wtime_s = omp_get_wtime();
+	fprintf(stdout, "CP_APR MU: \n");
+	KruskalModelNormalize(M);
+	// Iterate until covergence or max_iters reached
+	int iter;
+	for(iter = 0; iter < max_iters; iter++) {
+		bool converged = true;
+		for(int n = 0; n < nmodes; n++) {
+			IType dim = dims[n];
+			FType* B = U[n];
+			FType* Phi_n = Phi[n];
+
+			// Lines 4-5 in Algorithm 3 of the CP-APR paper
+			// Calculate B <- (A^)n) + S) lambda
+			if(iter > 0) {
+				bool any_violation = false;
+				for(IType i = 0; i < dim * rank; i++) {
+					if((B[i] < kappa_tol) && (Phi_n[i] > 1.0)) {
+						B[i] = B[i] + kappa;
+						any_violation = true;
+					}
+				}
+				if(any_violation) {
+					nViolations[iter]++;
+				}
+			}
+			// Redstribute Lambda
+			RedistributeLambda(M, n);
+
+			// Calculate Pi for every non-zero element
+			wtime_t = omp_get_wtime();
+			CalculatePi(Pi, X, M, n);
+			wtime_apr_pi += omp_get_wtime() - wtime_t;
+
+			// Iterate until convergence or max_inner_iters reached
+			for(int inner = 0; inner < max_inner_iters; inner++) {
+				nInnerIters[iter]++;
+
+				wtime_t = omp_get_wtime();
+				// Line 8 in Algorithm 3 of the CP-APR paper
+				// Calculate Phi^(n)
+				CalculatePhi(Phi_n, Pi, X, M, n, eps_div_zero);
+				wtime_apr_phi += omp_get_wtime() - wtime_t;
+
+				// Line 9-11 in Algorithm 3 of the CP-APR paper
+				// Check for convergence
+				FType kkt_violation = 0.0;
+				for(IType i = 0; i < dim * rank; i++) {
+					FType min_comp = fabs(fmin(B[i], 1.0 - Phi_n[i]));
+					kkt_violation = fmax(kkt_violation, min_comp);
+				}
+				kktModeViolations[n] = kkt_violation;
+				// calculate kkt_violation
+				if(kkt_violation < epsilon) {
+					break;
+				} else {
+					converged = false;
+				}
+
+				// Line 13 in Algorithm 3 of the CP-APR paper
+				// Do the multiplicative update
+				for(IType i = 0; i < dim * rank; i++) {
+					B[i] *= Phi_n[i];
+				}
+
+				/*
+				if(inner % 1 == 0) {
+					fprintf (stdout, "\tMode = %d, Inner iter = %d, ",
+							 n, inner);
+					fprintf (stdout, " KKT violation == %.6e\n",
+                             kktModeViolations[n]);
+                }
+				 */
+			} // for(int inner = 0; inner < max_inner_iters; inner++)
+
+			// Line 15-16 in Algorithm 3 of the CP-APR paper
+			// Shift weights from mode n back to Lambda and update A^(n)
+			// Basically, KruskalModelNormalize for only mode n
+			for(IType r = 0; r < rank; r++) {
+				FType tmp_sum = 0.0;
+				for(IType i = 0; i < dim; i++) {
+					tmp_sum += fabs(B[i * rank + r]);
+				}
+				for(IType i = 0; i < dim; i++) {
+					B[i * rank + r] /= tmp_sum;
+				}
+				lambda[r] *= tmp_sum;
+			}
+		} // for(int n = 0; n < nmodes; n++)
+
+		kktViolations[iter] = kktModeViolations[0];
+		for(int n = 0; n < nmodes; n++) {
+			kktViolations[iter] = fmax(kktViolations[iter],
+										kktModeViolations[n]);
+		}
+		if((iter % 10) == 0) {
+			fprintf (stdout, "Iter %d: Inner its = %d KKT violation = %.6e, ",
+						iter, nInnerIters[iter], kktViolations[iter]);
+			fprintf (stdout, "nViolations = %d\n", nViolations[iter]);
+		}
+
+		if(converged) {
+			fprintf(stdout, "Exiting since all subproblems reached KKT tol\n");
+			break;
+		}
+	} // for(iter = 0; iter < max_iters; iter++)
+	wtime_apr += omp_get_wtime() - wtime_s;
+
+
+	wtime_s = omp_get_wtime();
+	// Calculate the Log likelihood fit
+	int nTotalInner = 0;
+	if(iter == max_iters) {
+		iter = max_iters - 1;
+	}
+	for(int i = 0; i < iter + 1; i++) {
+		nTotalInner += nInnerIters[i];
+	}
+	FType obj = tt_logLikelihood(X, M, eps_div_zero);
+
+	// Calculate the Gram matrices of the factor matrices and
+	// last mode's MTTKRP
+	// Then use cpd_fit to calculate the fit - this should give you the
+	// least-squares fit
+	FType** tmp_grams = (FType**) AlignedMalloc(nmodes * sizeof(FType*));
+	assert(tmp_grams);
+	for(int n = 0; n < nmodes; n++) {
+		tmp_grams[n] = (FType*) AlignedMalloc(rank * rank * sizeof(FType));
+		assert(tmp_grams[n]);
+	}
+	for(int n = 0; n < nmodes; n++) {
+		update_gram(tmp_grams[n], M, n);
+	}
+
+	FType* tmp_mttkrp = (FType*) AlignedMalloc(dims[nmodes - 1] * rank *
+												sizeof(FType));
+	assert(tmp_mttkrp);
+	for(IType i = 0; i < dims[nmodes - 1] * rank; i++) {
+		tmp_mttkrp[i] = 0.0;
+	}
+	mttkrp_(X, M, nmodes - 1, tmp_mttkrp);
+	double fit = cpd_fit_(X, M, tmp_grams, tmp_mttkrp);
+	wtime_post += omp_get_wtime() - wtime_s;
+
+	fprintf(stdout, "  Final log-likelihood = %e\n", obj);
+	fprintf(stdout, "  Final least squares fit = %e\n", fit);
+	fprintf(stdout, "  Final KKT violation = %7.7e\n", kktViolations[iter]);
+	fprintf(stdout, "  Total outer iterations = %d\n", iter);
+	fprintf(stdout, "  Total inner iterations = %d\n", nTotalInner);
+
+	fprintf(stdout, "CP-APR pre-processing time  = %f (s)\n", wtime_pre);
+	fprintf(stdout, "CP-APR main iteration time  = %f (s)\n", wtime_apr);
+	fprintf(stdout, "CP-APR Pi accumulated time  = %f (s)\n", wtime_apr_pi);
+	fprintf(stdout, "CP-APR Phi accumulated time = %f (s)\n", wtime_apr_phi);
+	fprintf(stdout, "CP-APR post-processing time = %f (s)\n", wtime_post);
+	fprintf(stdout, "CP-APR TOTAL time           = %f (s)\n",
+			wtime_pre + wtime_apr + wtime_post);
+
+	fprintf(stdout, ">%f,%f,%f,%f,%f,%d,%d,%e,%e\n",
+			wtime_pre, wtime_apr, wtime_apr_pi, wtime_apr_phi, wtime_post,
+			iter, nTotalInner, obj, fit);
+
+}
+
+
+void CalculatePhi_OTF(FType* Phi, SparseTensor* X, KruskalModel* M, int target_mode, FType eps_div_zero)
+{
+	IType nmodes = X->nmodes;
+	IType nnz = X->nnz;
+	IType rank = M->rank;
+	IType** cidx = X->cidx;
+	FType* vals = X->vals;
+	FType** U = M->U;
+	FType* B = U[target_mode];
+	IType dim = X->dims[target_mode];
+
+	// Initialize Phi to 0
+	for(IType i = 0; i < dim * rank; i++) {
+		Phi[i] = 0.0;
+	}
+
+	// temporary array to store the KRP
+	FType row[rank];
+
+	for(IType i = 0; i < nnz; i++) {
+		IType row_index = cidx[target_mode][i];
+
+		// For each non-zero element, calculate the required KRP
+		for(IType r = 0; r < rank; r++) {
+			row[r] = 1.0;
+		}
+		for(IType n = 0; n < nmodes; n++) {
+			if(n != target_mode) {
+				IType row_index_n = cidx[n][i];
+				for(IType r = 0; r < rank; r++) {
+					row[r] *= U[n][row_index_n * rank + r];
+				}
+			}
+		}
+
+		// Calculate B*KRP
+		FType v = 0.0;
+		for(IType r = 0; r < rank; r++) {
+			v += B[row_index * rank + r] * row[r];
+		}
+		// divide nnz by this value
+		v = vals[i] / fmax(v, eps_div_zero);
+
+		// scale KR (i.e., row) by this value (i.e., v), and update Phi
+		for(IType r = 0; r < rank; r++) {
+			Phi[row_index * rank + r] += v * row[r];
+		}
+	}
+}
+
+
+
+
+void cp_apr_mu_alto_otf(SparseTensor* X, KruskalModel* M, int max_iters, int max_inner_iters, FType epsilon, FType eps_div_zero, FType kappa_tol, FType kappa)
+{
+    // timers
+    double wtime_s, wtime_t;
+    double wtime_pre = 0.0;
+    double wtime_apr = 0.0;
+    double wtime_apr_phi = 0.0;
+    double wtime_post = 0.0;
+
+	fprintf(stdout, "Running ALTO CP-APR with: \n");
+	// max outer iterations
+	fprintf(stdout, "\tmax iters:       %d\n", max_iters);
+	// max inner iterations
+	fprintf(stdout, "\tmax inner iters: %d\n", max_inner_iters);
+	// tolerance on the overall KKT violation
+	fprintf(stdout, "\ttolerance:       %.2e\n", epsilon);
+	// safeguard against divide by zero
+	fprintf(stdout, "\teps_div_zero:    %.2e\n", eps_div_zero);
+	// tolerance on complementary slackness
+	fprintf(stdout, "\tkappa_tol:       %.2e\n", kappa_tol);
+	// offset to fix complementary slackness
+	fprintf(stdout, "\tkappa:           %.2e\n", kappa);
+
+
+    wtime_s = omp_get_wtime();
+	// Tensor and factor matrices information
+	int nmodes = X->nmodes;
+	IType* dims = X->dims;
+	IType rank = M->rank;
+	FType** U = M->U;
+	FType* lambda = M->lambda;
+
+	// Intermediate matrices
+	// Phi matrix is an intermediate matrix equal in size to the factor matrix
+	FType** Phi = (FType**) AlignedMalloc(nmodes * sizeof(FType*));
+	assert(Phi);
+	for(int n = 0; n < nmodes; n++) {
+		Phi[n] = (FType*) AlignedMalloc(dims[n] * rank * sizeof(FType));
+		assert(Phi[n]);
+	}
+
+
+	// Used for keeping track of convergence information
+	FType* kktModeViolations = (FType*) AlignedMalloc(nmodes * sizeof(FType));
+	assert(kktModeViolations);
+	for(int n = 0; n < nmodes; n++) {
+		kktModeViolations[n] = 0.0;
+	}
+	int* nViolations = (int*) AlignedMalloc(max_iters * sizeof(int));
+	assert(nViolations);
+	for(int i = 0; i < max_iters; i++) {
+		nViolations[i] = 0;
+	}
+	FType* kktViolations = (FType*) AlignedMalloc(max_iters * sizeof(FType));
+	assert(kktViolations);
+	for(int i = 0; i < max_iters; i++) {
+		kktViolations[i] = 0.0;
+	}
+	int* nInnerIters = (int*) AlignedMalloc(max_iters * sizeof(int));
+	assert(nInnerIters);
+	for(int i = 0; i < max_iters; i++) {
+		nInnerIters[i] = 0;
+	}
+    wtime_pre += omp_get_wtime() - wtime_s;
+
+
+    wtime_s = omp_get_wtime();
+	fprintf(stdout, "CP_APR MU (OTF): \n");
+	KruskalModelNormalize(M);
+	// Iterate until covergence or max_iters reached
+	int iter;
+	for(iter = 0; iter < max_iters; iter++) {
+		bool converged = true;
+		for(int n = 0; n < nmodes; n++) {
+			IType dim = dims[n];
+			FType* B = U[n];
+			FType* Phi_n = Phi[n];
+
+			// Lines 4-5 in Algorithm 3 of the CP-APR paper
+			// Calculate B <- (A^)n) + S) lambda
+			if(iter > 0) {
+				bool any_violation = false;
+				for(IType i = 0; i < dim * rank; i++) {
+					if((B[i] < kappa_tol) && (Phi_n[i] > 1.0)) {
+						B[i] = B[i] + kappa;
+						any_violation = true;
+					}
+				}
+				if(any_violation) {
+					nViolations[iter]++;
+				}
+			}
+
+			// Redstribute Lambda
+			RedistributeLambda(M, n);
+
+			// Iterate until convergence or max_inner_iters reached
+			for(int inner = 0; inner < max_inner_iters; inner++) {
+				nInnerIters[iter]++;
+
+                wtime_t = omp_get_wtime();
+				// Line 8 in Algorithm 3 of the CP-APR paper
+				// Calculate Phi^(n)
+				CalculatePhi_OTF(Phi_n, X, M, n, eps_div_zero);
+                wtime_apr_phi += omp_get_wtime() - wtime_t;
+
+				// Line 9-11 in Algorithm 3 of the CP-APR paper
+				// Check for convergence
+				FType kkt_violation = 0.0;
+				for(IType i = 0; i < dim * rank; i++) {
+					FType min_comp = fabs(fmin(B[i], 1.0 - Phi_n[i]));
+					kkt_violation = fmax(kkt_violation, min_comp);
+				}
+				kktModeViolations[n] = kkt_violation;
+				// calculate kkt_violation
+				if(kkt_violation < epsilon) {
+					break;
+				} else {
+					converged = false;
+				}
+
+				// Line 13 in Algorithm 3 of the CP-APR paper
+				// Do the multiplicative update
+				for(IType i = 0; i < dim * rank; i++) {
+					B[i] *= Phi_n[i];
+				}
+
+				/*
+				if(inner % 1 == 0) {
+					fprintf (stdout, "\tMode = %d, Inner iter = %d, ",
+							 n, inner);
+					fprintf (stdout, " KKT violation == %.6e\n",
+                             kktModeViolations[n]);
+                }
+				 */
+			} // for(int inner = 0; inner < max_inner_iters; inner++)
+
+			// Line 15-16 in Algorithm 3 of the CP-APR paper
+			// Shift weights from mode n back to Lambda and update A^(n)
+			// Basically, KruskalModelNormalize for only mode n
+			for(IType r = 0; r < rank; r++) {
+				FType tmp_sum = 0.0;
+				for(IType i = 0; i < dim; i++) {
+					tmp_sum += fabs(B[i * rank + r]);
+				}
+				for(IType i = 0; i < dim; i++) {
+					B[i * rank + r] /= tmp_sum;
+				}
+				lambda[r] *= tmp_sum;
+			}
+		} // for(int n = 0; n < nmodes; n++)
+
+		kktViolations[iter] = kktModeViolations[0];
+		for(int n = 0; n < nmodes; n++) {
+			kktViolations[iter] = fmax(kktViolations[iter],
+										kktModeViolations[n]);
+		}
+		if((iter % 10) == 0) {
+			fprintf (stdout, "Iter %d: Inner its = %d KKT violation = %.6e, ",
+						iter, nInnerIters[iter], kktViolations[iter]);
+			fprintf (stdout, "nViolations = %d\n", nViolations[iter]);
+		}
+
+		if(converged) {
+			fprintf(stdout, "Exiting since all subproblems reached KKT tol\n");
+			break;
+		}
+	} // for(iter = 0; iter < max_iters; iter++)
+    wtime_apr += omp_get_wtime() - wtime_s;
+
+
+    wtime_s = omp_get_wtime();
+	// Calculate the Log likelihood fit
+	int nTotalInner = 0;
+	if(iter == max_iters) {
+		iter = max_iters - 1;
+	}
+	for(int i = 0; i < iter + 1; i++) {
+		nTotalInner += nInnerIters[i];
+	}
+	FType obj = tt_logLikelihood(X, M, eps_div_zero);
+
+	// Calculate the Gram matrices of the factor matrices and
+	// last mode's MTTKRP
+	// Then use cpd_fit to calculate the fit - this should give you the
+	// least-squares fit
+	FType** tmp_grams = (FType**) AlignedMalloc(nmodes * sizeof(FType*));
+	assert(tmp_grams);
+	for(int n = 0; n < nmodes; n++) {
+		tmp_grams[n] = (FType*) AlignedMalloc(rank * rank * sizeof(FType));
+		assert(tmp_grams[n]);
+	}
+	for(int n = 0; n < nmodes; n++) {
+		update_gram(tmp_grams[n], M, n);
+	}
+
+	FType* tmp_mttkrp = (FType*) AlignedMalloc(dims[nmodes - 1] * rank *
+												sizeof(FType));
+	assert(tmp_mttkrp);
+	for(IType i = 0; i < dims[nmodes - 1] * rank; i++) {
+		tmp_mttkrp[i] = 0.0;
+	}
+	mttkrp_(X, M, nmodes - 1, tmp_mttkrp);
+	double fit = cpd_fit_(X, M, tmp_grams, tmp_mttkrp);
+    wtime_post += omp_get_wtime() - wtime_s;
+
+
+	fprintf(stdout, "  Final log-likelihood = %e\n", obj);
+	fprintf(stdout, "  Final least squares fit = %e\n", fit);
+	fprintf(stdout, "  Final KKT violation = %7.7e\n", kktViolations[iter]);
+	fprintf(stdout, "  Total outer iterations = %d\n", iter);
+	fprintf(stdout, "  Total inner iterations = %d\n", nTotalInner);
+
+    fprintf(stdout, "CP-APR pre-processing time  = %f (s)\n", wtime_pre);
+    fprintf(stdout, "CP-APR main iteration time  = %f (s)\n", wtime_apr);
+    fprintf(stdout, "CP-APR Phi accumulated time = %f (s)\n", wtime_apr_phi);
+    fprintf(stdout, "CP-APR post-processing time = %f (s)\n", wtime_post);
+    fprintf(stdout, "CP-APR TOTAL time           = %f (s)\n",
+            wtime_pre + wtime_apr + wtime_post);
+
+    fprintf(stdout, ">,%f,%f,%.2f,%f,%f,%d,%d,%e,%e\n",
+            wtime_pre, wtime_apr, 0.0, wtime_apr_phi, wtime_post,
+            iter, nTotalInner, obj, fit);
+}
+
+/*
+
+template <typename LIT>
+void cp_apr_alto(AltoTensor<LIT>* AT, KruskalModel* M, int max_iters, int max_inner_iters, FType epsilon, FType eps_div_zero, FType kappa_tol, FType kappa)
+{
+
+
+}
+ */

--- a/src/apr.cpp
+++ b/src/apr.cpp
@@ -168,6 +168,7 @@ FType tt_logLikelihood(SparseTensor* X, KruskalModel* M, FType eps_div_zero)
 		}
 		lambda[r] = lambda[r] * temp;
 	}
+    AlignedFree(A);
 
 	return (logSum - factorSum);
 }
@@ -424,6 +425,7 @@ void cp_apr_mu_alto(SparseTensor* X, KruskalModel* M, int max_iters, int max_inn
 	if(iter == max_iters) {
 		iter = max_iters - 1;
 	}
+    assert(iter < max_iters);
 	for(int i = 0; i < iter + 1; i++) {
 		nTotalInner += nInnerIters[i];
 	}
@@ -470,6 +472,18 @@ void cp_apr_mu_alto(SparseTensor* X, KruskalModel* M, int max_iters, int max_inn
 	fprintf(stdout, ">%f,%f,%f,%f,%f,%d,%d,%e,%e\n",
 			wtime_pre, wtime_apr, wtime_apr_pi, wtime_apr_phi, wtime_post,
 			iter, nTotalInner, obj, fit);
+    AlignedFree(nInnerIters);
+    AlignedFree(nViolations);
+    AlignedFree(kktModeViolations);
+    AlignedFree(kktViolations);
+    AlignedFree(tmp_mttkrp);
+	AlignedFree(Pi);
+	for(int n = 0; n < nmodes; n++) {
+		AlignedFree(tmp_grams[n]);
+		AlignedFree(Phi[n]);
+    }
+    AlignedFree(tmp_grams);
+	AlignedFree(Phi);
 
 }
 
@@ -704,6 +718,7 @@ void cp_apr_mu_alto_otf(SparseTensor* X, KruskalModel* M, int max_iters, int max
 	if(iter == max_iters) {
 		iter = max_iters - 1;
 	}
+    assert(iter < max_iters);
 	for(int i = 0; i < iter + 1; i++) {
 		nTotalInner += nInnerIters[i];
 	}
@@ -750,6 +765,17 @@ void cp_apr_mu_alto_otf(SparseTensor* X, KruskalModel* M, int max_iters, int max
     fprintf(stdout, ">,%f,%f,%.2f,%f,%f,%d,%d,%e,%e\n",
             wtime_pre, wtime_apr, 0.0, wtime_apr_phi, wtime_post,
             iter, nTotalInner, obj, fit);
+    AlignedFree(nInnerIters);
+    AlignedFree(nViolations);
+    AlignedFree(kktModeViolations);
+    AlignedFree(kktViolations);
+    AlignedFree(tmp_mttkrp);
+	for(int n = 0; n < nmodes; n++) {
+		AlignedFree(tmp_grams[n]);
+		AlignedFree(Phi[n]);
+    }
+    AlignedFree(tmp_grams);
+	AlignedFree(Phi);
 }
 
 /*

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "common.hpp"
 #include "alto.hpp"
 #include "cpd.hpp"
+#include "apr.hpp"
 
 #include <unistd.h>
 #include <sys/resource.h>
@@ -24,7 +25,9 @@
 #include <string.h>
 
 #include <sched.h>
-#include <numaif.h>
+#ifdef memtrace
+  #include <numaif.h>
+#endif
 
 #if ALTO_MASK_LENGTH == 64
     typedef unsigned long long LIType;
@@ -42,7 +45,8 @@
 	exit(-1);							\
 } while (0)
 
-void BenchmarkAlto(SparseTensor* X, int max_iters, IType rank,
+void BenchmarkAlto(SparseTensor* X, Model model, int max_iters, int max_inner,
+                   FType kappa_tol, FType kappa, IType rank,
                    IType seed, int target_mode, int num_partitions);
 
 void RunAltoCheck(SparseTensor* X, IType rank, IType seed,
@@ -69,21 +73,24 @@ const struct option long_opt[] = {
     {"input",          1, NULL, 'i'},
     {"output",         1, NULL, 'o'},
     {"bin",            1, NULL, 'b'},
+    {"model",          1, NULL, 'l'},
     {"rank",           1, NULL, 'r'},
     {"max-iter",       1, NULL, 'm'},
+    {"max-inner",      1, NULL, 'n'},
     {"seed",           1, NULL, 'x'},
     {"dims",           1, NULL, 'd'},
     {"target-mode",    1, NULL, 't'},
     {"sparsity",       1, NULL, 's'},
     {"epsilon",        1, NULL, 'e'},
     {"file",           1, NULL, 'f'},
+    {"zero-based",     0, NULL, 'z'},
     {"check",          0, NULL, 'c'},
     {"bench",          0, NULL, 'p'},
     {NULL,             0, NULL,    0}
 };
 
-const char* const short_opt = "hvi:o:b:r:m:x:d:t:s:e:f:cp";
-const char* version_info = "0.1.1";
+const char* const short_opt = "hvi:o:b:l:r:m:n:x:d:t:s:e:f:zcp";
+const char* version_info = "0.1.2";
 
 int main(int argc, char** argv)
 {
@@ -96,20 +103,35 @@ int main(int argc, char** argv)
 	double t_create = 0.0;
 	double t_cpd = 0.0;
 
+	// Common to all models
 	int max_iters = 10;
 	IType rank = 16;
+	double epsilon = 1e-5;
+	int target_mode = -1;
 	std::vector<IType> dims;
 	int nmodes = 0;
-	int target_mode = -1;
+
+	// Common to APR
+	int max_inner = 10;
+	FType eps_div_zero = 1.0e-10;
+	FType kappa_tol = 1.0e-10;
+	FType kappa = 1.0e-2;
+
+	// Tensor I/O
 	std::string text_file;
 	std::string text_file_out;
 	std::string binary_file;
+    IType zero_based = 0;
+
+	// Generating test tensor
 	double sparsity = 0.1;
-	double epsilon = 1e-5;
+
 	int seed = time(NULL);
 	int save_to_file = 0;
     bool do_check = false;
-    bool do_mttkrp_bench = false;
+    bool do_bench = false;
+    std::string model_string;
+    Model model;
 
 	int c = 0;
 	while ((c = getopt_long(argc, argv, short_opt, long_opt, NULL)) != -1) {
@@ -129,6 +151,17 @@ int main(int argc, char** argv)
 		case 'b':
 			binary_file = std::string(optarg);
 			break;
+		case 'l':
+            // choose the type of model to compute (ALS, APR, etc.)
+			model_string = std::string(optarg);
+            if(model_string == "ALS" || model_string == "als") {
+				model = ALS;
+            } else if(model_string == "APR" || model_string == "apr") {
+				model = APR;
+            } else {
+				fprintf(stderr, "Invalid -model: %s.\n", optarg);
+            }
+			break;
 		case 'r':
 			rank = (IType)atoll(optarg);
 			if (rank < 1) {
@@ -139,6 +172,12 @@ int main(int argc, char** argv)
 			max_iters = atoi(optarg);
 			if (max_iters < 0) {
 				fprintf(stderr, "Invalid -max-iter: %s.\n", optarg);
+			}
+			break;
+		case 'n':
+			max_inner = atoi(optarg);
+			if (max_iters < 0) {
+				fprintf(stderr, "Invalid -max-inner: %s.\n", optarg);
 			}
 			break;
 		case 'x':
@@ -178,11 +217,14 @@ int main(int argc, char** argv)
 				fprintf(stderr, "Invalid -file: %s.\n", optarg);
 			}
 			break;
+        case 'z':
+            zero_based = 1;
+            break;
         case 'c':
             do_check = true;
             break;
         case 'p':
-            do_mttkrp_bench = true;
+            do_bench = true;
             break;
 		case ':':
 			fprintf(stderr, "Option -%c requires an argument.\n", optopt);
@@ -205,7 +247,7 @@ int main(int argc, char** argv)
 	SparseTensor* X = NULL;
 	if (!binary_file.empty()) {
 		BEGIN_TIMER(&ticks_start);
-		ImportSparseTensor(binary_file.c_str(), BINARY_FORMAT, &X);
+		ImportSparseTensor(binary_file.c_str(), BINARY_FORMAT, &X, zero_based);
 		END_TIMER(&ticks_end);
 		ELAPSED_TIME(ticks_start, ticks_end, &t_read);
 		PRINT_TIMER("Reading binary file", t_read);
@@ -220,7 +262,7 @@ int main(int argc, char** argv)
 	}
 	else if (!text_file.empty()) {
 		BEGIN_TIMER(&ticks_start);
-		ImportSparseTensor(text_file.c_str(), TEXT_FORMAT, &X);
+		ImportSparseTensor(text_file.c_str(), TEXT_FORMAT, &X, zero_based);
 		END_TIMER(&ticks_end);
 		ELAPSED_TIME(ticks_start, ticks_end, &t_read);
 		PRINT_TIMER("Reading text file", t_read);
@@ -260,7 +302,7 @@ int main(int argc, char** argv)
         RunAltoCheck(X, rank, seed, target_mode, omp_get_max_threads());
         return 0;
     }
-    if (do_mttkrp_bench) {
+    if (do_bench) {
 #ifdef memtrace
 	printf("After initialization\n");
 	long long post_n0, post_n1;
@@ -269,7 +311,7 @@ int main(int argc, char** argv)
 	printf("memory N0 %lld B N1 %lld B\n", (post_n0 - pre_n0), (post_n1 - pre_n1));
 #endif
     	// adjust target mode and number of partitions accordingly
-	    BenchmarkAlto(X, max_iters, rank, seed, target_mode, omp_get_max_threads());
+	    BenchmarkAlto(X, model, max_iters, max_inner, kappa_tol, kappa, rank, seed, target_mode, omp_get_max_threads());
 #ifdef memtrace
 	printf("After compute\n");
 
@@ -288,6 +330,7 @@ int main(int argc, char** argv)
 	KruskalModelRandomInit(M, (unsigned int)seed);
 	// PrintKruskalModel(M);
 
+    // Reference naive COO CPD
 	/*BEGIN_TIMER(&ticks_start);
 	cpd(X, M, max_iters, epsilon);
 	END_TIMER(&ticks_end);
@@ -300,23 +343,38 @@ int main(int argc, char** argv)
 	AltoTensor<LIType>* AT;
 	int num_partitions = omp_get_max_threads();
 	create_alto(X, &AT, num_partitions);
+	DestroySparseTensor(X);
 
-    BEGIN_TIMER(&ticks_start);
-    cpd_alto(AT, M, max_iters, epsilon);
-    // cpd(X, M, max_iters, epsilon);
-    END_TIMER(&ticks_end);
-    ELAPSED_TIME(ticks_start, ticks_end, &t_cpd);
-    PRINT_TIMER("CPD (ALTO)", t_cpd);
+	BEGIN_TIMER(&ticks_start);
+	if(model == ALS) {
+    	cpd_alto(AT, M, max_iters, epsilon);
+    	// cpd(X, M, max_iters, epsilon);
+	} else if(model == APR) {
+		// cp_apr_mu_alto(X, M, max_iters, max_inner, epsilon, eps_div_zero,
+						// kappa_tol, kappa);
+		// cp_apr_mu_alto_otf(X, M, max_iters, max_inner, epsilon, eps_div_zero,
+							// kappa_tol, kappa);
+		cp_apr_alto(AT, M, max_iters, max_inner, epsilon, eps_div_zero,
+					kappa_tol, kappa, false);
+
+	} else {
+		fprintf(stderr, "Invalid model\n");
+	}
+	END_TIMER(&ticks_end);
+	ELAPSED_TIME(ticks_start, ticks_end, &t_cpd);
+    if(model == ALS) {
+		PRINT_TIMER("ALS (ALTO)", t_cpd);
+	} else if(model == APR) {
+		PRINT_TIMER("APR (ALTO)", t_cpd);
+	}
 
     // Cleanup
-	DestroySparseTensor(X);
 	DestroyKruskalModel(M);
-	destroy_alto(AT);
-
+	//destroy_alto(AT);
 	return 0;
 }
 
-void BenchmarkAlto(SparseTensor* X, int max_iters, IType rank,
+void BenchmarkAlto(SparseTensor* X, Model model, int max_iters, int max_inner, FType kappa_tol, FType kappa, IType rank,
                    IType seed, int target_mode, int num_partitions)
 {
 	double wtime_s, wtime;
@@ -340,22 +398,24 @@ void BenchmarkAlto(SparseTensor* X, int max_iters, IType rank,
 	post_n1 = node_mem(1, "Active:");
 	printf("\nmemory N0 %lld B N1 %lld B\n", (post_n0 - pre_n0), (post_n1 - pre_n1));
 #endif
-	FType** factors = (FType**)AlignedMalloc(X->nmodes * sizeof(FType*));
+    FType** factors = (FType**)AlignedMalloc(X->nmodes * sizeof(FType*));
 	assert(factors);
-	for (int m = 0; m < X->nmodes; m++) {
-        factors[m] = (FType*)AlignedMalloc(X->dims[m] * rank * sizeof(FType));
-		assert(factors[m]);
-	}
-	// Initialize factors
-	for (int m = 0; m < X->nmodes; ++m) {
-		ParMemcpy(factors[m], M->U[m], X->dims[m] * rank * sizeof(FType));
-	}
+    if (model == ALS) {
+    	for (int m = 0; m < X->nmodes; m++) {
+            factors[m] = (FType*)AlignedMalloc(X->dims[m] * rank * sizeof(FType));
+		    assert(factors[m]);
+    	}
+	    // Initialize factors
+    	for (int m = 0; m < X->nmodes; ++m) {
+	    	ParMemcpy(factors[m], M->U[m], X->dims[m] * rank * sizeof(FType));
+    	}
 #ifdef memtrace
-	printf("After factors allocation \n");
-	post_n0 = node_mem(0, "Active:");
-	post_n1 = node_mem(1, "Active:");
-	printf("\nmemory N0 %lld B N1 %lld B\n", (post_n0 - pre_n0), (post_n1 - pre_n1));
+	    printf("After factors allocation \n");
+	    post_n0 = node_mem(0, "Active:");
+	    post_n1 = node_mem(1, "Active:");
+	    printf("\nmemory N0 %lld B N1 %lld B\n", (post_n0 - pre_n0), (post_n1 - pre_n1));
 #endif
+    }
 	// ---------------------------------------------------------------- //
 	// Create ALTO tensor from COO
 	AltoTensor<LIType>* AT;
@@ -369,68 +429,81 @@ void BenchmarkAlto(SparseTensor* X, int max_iters, IType rank,
 	post_n1 = node_mem(1, "Active:");
 	printf("\nmemory N0 %lld B N1 %lld B\n", (post_n0 - pre_n0), (post_n1 - pre_n1));
 #endif
-    DestroyKruskalModel(M);
     DestroySparseTensor(X);
+    if (model == APR) {
+        cp_apr_alto(AT, M, max_iters, max_inner, 0.0, 0.0, kappa_tol, kappa, true);
+    }
+    else {
+        DestroyKruskalModel(M);
 #ifdef memtrace
-	printf("After deletion of SparseTensor\n");
-	post_n0 = node_mem(0, "Active:");
-	post_n1 = node_mem(1, "Active:");
-	printf("\nmemory N0 %lld B N1 %lld B\n", (post_n0 - pre_n0), (post_n1 - pre_n1));
+	    printf("After deletion of SparseTensor\n");
+	    post_n0 = node_mem(0, "Active:");
+	    post_n1 = node_mem(1, "Active:");
+	    printf("\nmemory N0 %lld B N1 %lld B\n", (post_n0 - pre_n0), (post_n1 - pre_n1));
 #endif
-	// set up OpenMP locks
-    omp_lock_t* writelocks = NULL;
-	//IType max_mode_len = 0;
-	//for (IType i = 0; i < M->mode; ++i) {
-	//	if (max_mode_len < M->dims[i]) {
-	//		max_mode_len = M->dims[i];
-	//	}
-	//}
-	//omp_lock_t* writelocks = (omp_lock_t*)AlignedMalloc(sizeof(omp_lock_t) *
-	//	max_mode_len);
-	//assert(writelocks);
-	//for (IType i = 0; i < max_mode_len; ++i) {
-	//	omp_init_lock(&(writelocks[i]));
-	//}
-	FType** ofibs = NULL;
-	create_da_mem(target_mode, rank, AT, &ofibs);
+        // set up OpenMP locks
+        omp_lock_t* writelocks = NULL;
+	    //IType max_mode_len = 0;
+	    //for (IType i = 0; i < M->mode; ++i) {
+	    //	if (max_mode_len < M->dims[i]) {
+	    //		max_mode_len = M->dims[i];
+	    //	}
+	    //}
+	    //omp_lock_t* writelocks = (omp_lock_t*)AlignedMalloc(sizeof(omp_lock_t) *
+	    //	max_mode_len);
+	    //assert(writelocks);
+	    //for (IType i = 0; i < max_mode_len; ++i) {
+	    //	omp_init_lock(&(writelocks[i]));
+	    //}
+	    FType** ofibs = NULL;
+	    create_da_mem(target_mode, rank, AT, &ofibs);
 
 #ifdef memtrace
-	printf("After create_da_mem \n");
-	post_n0 = node_mem(0, "Active:");
-	post_n1 = node_mem(1, "Active:");
-	printf("\nmemory N0 %lld B N1 %lld B\n", (post_n0 - pre_n0), (post_n1 - pre_n1));
+	    printf("After create_da_mem \n");
+	    post_n0 = node_mem(0, "Active:");
+	    post_n1 = node_mem(1, "Active:");
+	    printf("\nmemory N0 %lld B N1 %lld B\n", (post_n0 - pre_n0), (post_n1 - pre_n1));
 #endif
-    // warmup
-	if (target_mode == -1) {
-		for (int m = 0; m < AT->nmode; ++m) {
-			mttkrp_alto_par(m, factors, rank, AT, writelocks, ofibs);
-		}
-	} else {
-		 mttkrp_alto_par(target_mode, factors, rank, AT, writelocks, ofibs);
-	}
-	// Do ALTO mttkrp
-	wtime_s = omp_get_wtime();
-	for (int i = 0; i < max_iters; ++i) {
+        // warmup
 		if (target_mode == -1) {
 			for (int m = 0; m < AT->nmode; ++m) {
 				mttkrp_alto_par(m, factors, rank, AT, writelocks, ofibs);
 			}
-		}
-		else {
+		} else {
 			mttkrp_alto_par(target_mode, factors, rank, AT, writelocks, ofibs);
 		}
-	}
-	wtime = omp_get_wtime() - wtime_s;
-	printf("ALTO runtime:   %f\n", wtime);
+	    // Do ALTO mttkrp
+	    wtime_s = omp_get_wtime();
+	    for (int i = 0; i < max_iters; ++i) {
+	    	if (target_mode == -1) {
+	    		for (int m = 0; m < AT->nmode; ++m) {
+	    			mttkrp_alto_par(m, factors, rank, AT, writelocks, ofibs);
+	    		}
+	    	}
+	    	else {
+	    		mttkrp_alto_par(target_mode, factors, rank, AT, writelocks, ofibs);
+	    	}
+	    }
+	    wtime = omp_get_wtime() - wtime_s;
+	    printf("ALTO runtime:   %f\n", wtime);
+		for(int m = 0; m < AT->nmode; m++) {
+			AlignedFree(factors[m]);
+		}
+		AlignedFree(factors);
+	    destroy_da_mem(AT, ofibs, rank, target_mode);
+    }
 #ifdef memtrace
-	printf("After mttkrp_alto_par \n");
-	post_n0 = node_mem(0, "Active:");
-	post_n1 = node_mem(1, "Active:");
-	printf("\nmemory N0 %lld B N1 %lld B\n", (post_n0 - pre_n0), (post_n1 - pre_n1));
+	    printf("After benchmark \n");
+	    post_n0 = node_mem(0, "Active:");
+	    post_n1 = node_mem(1, "Active:");
+	    printf("\nmemory N0 %lld B N1 %lld B\n", (post_n0 - pre_n0), (post_n1 - pre_n1));
 #endif
 	// ---------------------------------------------------------------- //
 	// Cleanup
-	destroy_da_mem(AT, ofibs, rank, target_mode);
+    if (model == APR) {
+        DestroyKruskalModel(M);
+        // DestroySparseTensor(X);
+    }
 	destroy_alto(AT);
 	// ---------------------------------------------------------------- //
 }
@@ -454,15 +527,19 @@ void RunAltoCheck(SparseTensor* X, IType rank, IType seed,
     assert(truth);
     FType **factors = (FType **) AlignedMalloc(X->nmodes * sizeof(FType*));
     assert(factors);
+    FType **init_factors = (FType **) AlignedMalloc(X->nmodes * sizeof(FType*));
+    assert(init_factors);
     for(int m = 0; m < X->nmodes; m++) {
         truth[m] = (FType *) AlignedMalloc(X->dims[m] * rank * sizeof(FType));
         assert(truth[m]);
         factors[m] = (FType *) AlignedMalloc(X->dims[m] * rank * sizeof(FType));
         assert(factors[m]);
+        init_factors[m] = (FType *) AlignedMalloc(X->dims[m] * rank * sizeof(FType));
+        assert(init_factors[m]);
     }
     // Initialize factors
     for(int m = 0; m < X->nmodes; ++m) {
-        memcpy(factors[m], M->U[m], X->dims[m] * rank * sizeof(FType));
+        ParMemcpy(init_factors[m], M->U[m], X->dims[m] * rank * sizeof(FType));
     }
     // ---------------------------------------------------------------- //
     // Do base mttkrp
@@ -472,51 +549,69 @@ void RunAltoCheck(SparseTensor* X, IType rank, IType seed,
             printf("mode %d...", m);
             fflush(stdout);
             mttkrp(X, M, (IType) m);
+        	ParMemcpy(truth[m], M->U[m], X->dims[m] * rank * sizeof(FType));
+        	ParMemcpy(M->U[m], init_factors[m], X->dims[m] * rank * sizeof(FType)); //reset
         }
         printf("\n");
     } else {
         mttkrp(X, M, (IType) target_mode);
+		ParMemcpy(truth[target_mode], M->U[target_mode], X->dims[target_mode] * rank * sizeof(FType));
+		ParMemcpy(M->U[target_mode], init_factors[target_mode], X->dims[target_mode] * rank * sizeof(FType)); //reset
     }
     printf("   MTTKRP sequential base run done.\n");
-    // Copy to ground truth
-    for (int m = 0; m < X->nmodes; ++m) {
-        memcpy(truth[m], M->U[m], X->dims[m] * rank * sizeof(FType));
-    }
+
     // ---------------------------------------------------------------- //
     // Create ALTO tensor from COO
     printf("===Create ALTO tensors===\n");
     AltoTensor<LIType> *AT;
     create_alto(X, &AT, num_partitions);
+    DestroySparseTensor(X);
 
     FType **ofibs = NULL;
 	create_da_mem(target_mode, rank, AT, &ofibs);
 
     printf("===Run ALTO MTTKRP===\n");
-    wtime_s = omp_get_wtime();
     if (target_mode == -1) {
         for (int m = 0; m < AT->nmode; ++m) {
             printf("mode %d...", m);
             fflush(stdout);
-            mttkrp_alto_par(m, factors, rank, AT, NULL, ofibs);
+            mttkrp_alto_par(m, init_factors, rank, AT, NULL, ofibs);
+			ParMemcpy(factors[m], init_factors[m], AT->dims[m] * rank * sizeof(FType));
+			ParMemcpy(init_factors[m], M->U[m], AT->dims[m] * rank * sizeof(FType)); //reset
         }
         printf("\n");
     } else {
-        mttkrp_alto_par(target_mode, factors, rank, AT, NULL, ofibs);
+        mttkrp_alto_par(target_mode, init_factors, rank, AT, NULL, ofibs);
+		ParMemcpy(factors[target_mode], init_factors[target_mode], AT->dims[target_mode] * rank * sizeof(FType));
     }
-    wtime = omp_get_wtime() - wtime_s;
-    printf("   ALTO runtime: %f s\n", wtime);
+
     // ---------------------------------------------------------------- //
     // Verify ALTO
     printf("===Verify ALTO MTTKRP=== (target mode: %d)\n", target_mode);
-    for (int m = 0; m < AT->nmode; ++m) {
-        printf("mode %d: ", m);
-        fflush(stdout);
-        VerifyResult("mttkrp_alto", truth[m], factors[m], AT->dims[m] * rank);
-    }
+    if (target_mode == -1) {
+		for (int m = 0; m < AT->nmode; ++m) {
+			printf("mode %d: ", m);
+			fflush(stdout);
+			VerifyResult("mttkrp_alto", truth[m], factors[m], AT->dims[m] * rank);
+		}
+		printf("\n");
+    } else {
+		printf("mode %d: ", target_mode);
+		fflush(stdout);
+		VerifyResult("mttkrp_alto", truth[target_mode], factors[target_mode], AT->dims[target_mode] * rank);
+	}
     // ---------------------------------------------------------------- //
     // Cleanup
+	for(int m = 0; m < AT->nmode; m++) {
+		AlignedFree(truth[m]);
+		AlignedFree(factors[m]);
+		AlignedFree(init_factors[m]);
+	}
+	AlignedFree(truth);
+	AlignedFree(factors);
+	AlignedFree(init_factors);
 	destroy_da_mem(AT, ofibs, rank, target_mode);
-    DestroySparseTensor(X);
+	DestroyKruskalModel(M);
     destroy_alto(AT);
     // ---------------------------------------------------------------- //
 }
@@ -604,16 +699,19 @@ static void Usage(char* call)
 	fprintf(stderr, "\t-i or --input        Input tensor file in text\n");
 	fprintf(stderr, "\t-o or --output       Output tensor to file\n");
 	fprintf(stderr, "\t-b or --bin          Input tensor file in binary\n");
+    fprintf(stderr, "\t-z or --zero-based   Assume input tensor is zero-based (default: one-based)\n");
+	fprintf(stderr, "\t-l or --model        CPD model (ALS or APR)\n");
 	fprintf(stderr, "\t-f or --file         Save tensor to another format\n");
 	fprintf(stderr, "\t-r or --rank         Rank\n");
-	fprintf(stderr, "\t-m or --max-iter     Maximum outter iterations\n");
+	fprintf(stderr, "\t-m or --max-iter     Maximum outer iterations\n");
+	fprintf(stderr, "\t-n or --max-inner    Maximum inner iterations\n");
 	fprintf(stderr, "\t-t or --target-mode  Target mode of tensor\n");
 	fprintf(stderr, "\t-e or --epsilon      Convergence criteria\n");
 	fprintf(stderr, "\t-x or --seed         Random value seed\n");
 	fprintf(stderr, "\t-d or --dims         Dimension lenghts (I,J,K)\n");
 	fprintf(stderr, "\t-s or --sparsity     Sparsity of generate tensor\n");
     fprintf(stderr, "\t-c or --check        Run ALTO (par) validation against cpd MTTKRP\n");
-    fprintf(stderr, "\t-p or --bench        Run ALTO (par) MTTKRP benchmark with the given CMD line options\n");
+    fprintf(stderr, "\t-p or --bench        Run ALTO benchmark mode based on the CPD model with the given CMD line options\n");
 }
 
 static void PrintTensorInfo(IType rank, int max_iters, SparseTensor* X)
@@ -627,16 +725,16 @@ static void PrintTensorInfo(IType rank, int max_iters, SparseTensor* X)
 		tmp *= dims[i];
 	}
 	double sparsity = ((double)nnz) / tmp;
-	fprintf(stderr, "# Modes         = %u\n", nmodes);
-	fprintf(stderr, "Rank            = %llu\n", rank);
-	fprintf(stderr, "Sparsity        = %f\n", sparsity);
-	fprintf(stderr, "Max iters       = %d\n", max_iters);
-	fprintf(stderr, "Dimensions      = [%llu", dims[0]);
+	fprintf(stdout, "# Modes         = %u\n", nmodes);
+	fprintf(stdout, "Rank            = %llu\n", rank);
+	fprintf(stdout, "Sparsity        = %f\n", sparsity);
+	fprintf(stdout, "Max iters       = %d\n", max_iters);
+	fprintf(stdout, "Dimensions      = [%llu", dims[0]);
 	for (int i = 1; i < nmodes; i++) {
-		fprintf(stderr, " X %llu", dims[i]);
+		fprintf(stdout, " X %llu", dims[i]);
 	}
-	fprintf(stderr, "]\n");
-	fprintf(stderr, "NNZ             = %llu\n", nnz);
+	fprintf(stdout, "]\n");
+	fprintf(stdout, "NNZ             = %llu\n", nnz);
 }
 
 #ifdef memtrace

--- a/src/rng_stream.cpp
+++ b/src/rng_stream.cpp
@@ -16,16 +16,6 @@ void DestroyRNGStream(void *stream)
 }
 
 
-void RNGStreamUniform(void * stream, double low, double high,
-                      size_t len_v, double *v)
-{
-    RNG *rng = (RNG *)stream;
-    for (size_t i = 0; i < len_v; i++) {
-        v[i] = rng_randfp64(rng) * (high - low) + low;
-    }
-}
-
-
 void RNGStream64(void * stream, size_t len_v, uint64_t *v)
 {
     RNG *rng = (RNG *)stream;

--- a/src/sptensor.cpp
+++ b/src/sptensor.cpp
@@ -208,29 +208,35 @@ void ImportSparseTensor(
     *X_ = ten;
 
   } else if (f == BINARY_FORMAT) {
+    IType numobjs = 0;
     // first read the number of modes
     nmodes = 0;
-    fread(&nmodes, sizeof(IType), 1, fp);
+    numobjs = (IType) fread(&nmodes, sizeof(IType), 1, fp);
     assert(nmodes <= MAX_NUM_MODES);
+    assert(numobjs == (IType) 1);
 
     // use this information to read the dimensions of the tensor
     IType* dims = (IType*) AlignedMalloc(sizeof(IType) * nmodes);
     assert(dims);
-    fread(dims, sizeof(IType), nmodes, fp);
+    numobjs = (IType) fread(dims, sizeof(IType), nmodes, fp);
+    assert(numobjs == nmodes);
     // read the nnz
     nnz = 0;
-    fread(&nnz, sizeof(IType), 1, fp);
+    numobjs = (IType) fread(&nnz, sizeof(IType), 1, fp);
+    assert(numobjs = (IType) 1);
     // use this information to read the index and the values
     IType** cidx = (IType**) AlignedMalloc(sizeof(IType*) * nmodes);
     assert(cidx);
     for(IType i = 0; i < nmodes; i++) {
         cidx[i] = (IType*) AlignedMalloc(sizeof(IType) * nnz);
         assert(cidx[i]);
-        fread(cidx[i], sizeof(IType), nnz, fp);
+        numobjs = (IType) fread(cidx[i], sizeof(IType), nnz, fp);
+        assert(numobjs == nnz);
     }
     FType* vals = (FType*) malloc(sizeof(FType) * nnz);
     assert(vals);
-    fread(vals, sizeof(FType), nnz, fp);
+    numobjs = (IType) fread(vals, sizeof(FType), nnz, fp);
+    assert(numobjs == nnz);
 
     // create the sptensor
     SparseTensor* ten = (SparseTensor*) AlignedMalloc(sizeof(SparseTensor));

--- a/src/sptensor.cpp
+++ b/src/sptensor.cpp
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <limits.h>
 #include <math.h>
 #include <assert.h>
 #include <time.h>
@@ -223,7 +224,13 @@ void ImportSparseTensor(
     // read the nnz
     nnz = 0;
     numobjs = (IType) fread(&nnz, sizeof(IType), 1, fp);
-    assert(numobjs = (IType) 1);
+    assert(numobjs == (IType) 1);
+    assert(nnz > 0);
+#ifdef IDX_TYPE32
+    assert(nnz <= UINT_MAX);
+#else
+    assert(nnz <= ULLONG_MAX);
+#endif
     // use this information to read the index and the values
     IType** cidx = (IType**) AlignedMalloc(sizeof(IType*) * nmodes);
     assert(cidx);


### PR DESCRIPTION
This PR includes multiple enhancements and features for ALTO, mainly:
- The code now supports CP Alternating Poisson Regression (CP-APR) with the ALTO format (mainly implemented in `include/apr.hpp` and a serial version in `src/apr.cpp`). The algorithm and the benefit of using ALTO for it over state-of-the-art implementation can be found in the pre-print on Arxiv (https://arxiv.org/abs/2403.06348). For the update of phi we support two different versions, namely an on-the-fly update and the usage of a pre-computed phi matrix. This is also described in the paper.
- The code now supports to distinguish between different data types for the index, the precision of the floating point type and the sparse tensor value since CP-APR works with count data (i.e., `INT32` or `INT64`). This can be changed in the `config.mk` file and I added a description in the `README.md`
- The code supports the computation of zero-based tensors now (previously, only the import of one-based tensors were supported)
- We added a new alternative tensor traversal method (output-oriented) and significantly improved the parallel performance of the CP-ALS and CP-APR algorithms by selecting the best tensor traversal method, depending on the characteristics of the target tensor